### PR TITLE
feat: fan-out / map / loop showcase workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ uv run horus run workflow.yaml
 | W-04 | [Ligand Parameterization](workflows/bioexcel_building_blocks/w02-ligand-parameterization/README.md) | Generate GROMACS force-field parameters for a small-molecule ligand via OpenBabel and ACPype/GAFF |
 | W-05 | [AMBER MD Setup](workflows/bioexcel_building_blocks/w03-amber-md-setup/README.md) | Full MD setup for lysozyme 1AKI using AMBER: LEaP topology → solvation → equilibration → production MD + analysis |
 
+### Engine Showcases
+
+Small, self-contained workflows that demonstrate horus-runtime engine
+features rather than a science domain. Requires horus-runtime ≥ the
+Dynamic-workflows features (milestone: fan-out/map/loops).
+
+| ID | Workflow | Description |
+|---|---|---|
+| W-06 | [Fan-out / Map / Gather](workflows/engine-showcases/w01-fanout-map-gather/README.md) | Split a collection into batches, map a stage over them concurrently, gather N results into one folder |
+| W-07 | [Programmatic Dynamic DAG](workflows/engine-showcases/w02-programmatic-dynamic-dag/README.md) | A task generates downstream tasks at runtime from the data it reads, via `add_task`/`expand` |
+| W-08 | [Bounded Loop (Range Map)](workflows/engine-showcases/w03-loop-map/README.md) | Run a fixed number of deterministic iterations with `map: {range: N}` and gather the results |
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to add new workflows or improve existing ones.

--- a/workflows/engine-showcases/w01-fanout-map-gather/README.md
+++ b/workflows/engine-showcases/w01-fanout-map-gather/README.md
@@ -1,0 +1,95 @@
+# W-06 · Fan-out / Map / Gather Showcase
+
+![Domain: Engine Showcases](https://img.shields.io/badge/domain-engine--showcases-orange)
+
+> Requires horus-runtime ≥ the Dynamic-workflows features (milestone: fan-out/map/loops).
+
+## Overview
+
+A minimal, portable demonstration of horus-runtime's declarative `map:`
+construct: a producer task splits a small input collection into batches, a
+`map:` block fans a stage out over every batch **concurrently**, and a gather
+stage collects the N results back into a single folder. There's no science
+here (no conda envs, no domain data) — every task shells out to `echo`/`wc`/`tr`
+or a stdlib-only script, so the whole thing runs anywhere in a few seconds and
+is meant to be read as a template for wiring up map/fan-out/fan-in on a real
+pipeline (e.g. batching a ligand library the way W-01/W-02 do, but with the
+new engine-level fan-out instead of a single serial stage).
+
+## Pipeline
+
+```
+split (local)             examples/items.json (8 strings) ──► batches/ (4 files)
+   │  chunks the JSON list into batch_0..batch_3.txt, 2 items each
+
+score[00..03] (map, 4x concurrent clones over batches/)
+   │  each clone: word-counts + uppercases its one batch file
+   │  ──► scored/count.txt, scored/upper.txt   (fan-in target: score.gathered/<i>/)
+
+gather (local)             score.gathered/ (4 subfolders) ──► results/summary/
+   │  sums the per-batch word counts, concatenates the uppercased text
+```
+
+## Quick start
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+cd workflows/engine-showcases/w01-fanout-map-gather
+uv sync
+# or: pip install horus-runtime
+
+horus run workflow.yaml
+```
+
+Outputs land in `workflow_results/`: `batches/` (4 files), `score.gathered/`
+(4 subfolders, one per clone), and `results/summary/summary.json` +
+`results/summary/combined_upper.txt`.
+
+## Inputs / Outputs
+
+**Input** — `examples/items.json`: a JSON array of 8 short strings.
+
+**Outputs**
+- `score.gathered/<i>/scored/count.txt` — word count for batch `<i>` (1 per
+  clone, always `2` for the bundled example: 2 items/batch, 1 word each).
+- `score.gathered/<i>/scored/upper.txt` — the batch's text, uppercased.
+- `results/summary/summary.json` — `{"total_words": 8, "batches": [...]}` for
+  the bundled example (4 batches × 2 words).
+- `results/summary/combined_upper.txt` — every batch's uppercased text,
+  concatenated in batch order.
+
+## Parameterization
+
+- `examples/items.json` — swap in your own JSON array of items.
+- `split` task's `--batch-size` arg (`workflow.yaml`) — items per batch; the
+  number of batches this produces is the number of concurrent `score` clones
+  the `map:` block creates.
+
+## Implementation notes
+
+- The `map:` block on the `score` task (`workflow.yaml`) is the whole showcase:
+  `over` names the upstream producer (`split`) and which of its outputs to
+  fan out over (`batches`, a folder — one clone per file inside it); `template`
+  is the task spec cloned once per item; `gather` names the downstream task +
+  input artifact id that receives the fan-in. No `edges:` entry is needed for
+  `split → score → gather` — the `map:` block is itself sufficient for the
+  loader to derive the fan-out/fan-in edges.
+- Per-clone outputs land under `score.gathered/<i>/` (`<i>` zero-indexed in
+  clone order); the `gather` task's single `folder` input reads that whole
+  tree at once rather than per-clone edges — that's how N results collapse
+  into 1 fan-in artifact.
+- Both scripts (`scripts/split.py`, `scripts/gather_summary.py`) are stdlib-only
+  and have a `--selftest` (`python scripts/split.py --selftest`).
+- The exact `map:` field names here (`over.source_task`, `over.source_output`,
+  `over.item_input`, `gather.task`, `gather.input`) reflect the `MapOver` /
+  `MapExpander` design in horus-runtime issues #113–#115 (milestone "Dynamic
+  workflows: fan-out / map / loops") as of writing; double-check against the
+  released schema if it has since shifted.
+
+## References
+
+- horus-runtime milestone: [Dynamic workflows: fan-out / map / loops](https://github.com/temple-compute/horus-runtime/milestone/6)
+- horus-runtime #115 — Declarative map / fan-out / fan-in (MapExpander)
+- horus-runtime #114 — Fan-in edge model: transfer flag on WorkflowEdge

--- a/workflows/engine-showcases/w01-fanout-map-gather/examples/items.json
+++ b/workflows/engine-showcases/w01-fanout-map-gather/examples/items.json
@@ -1,0 +1,1 @@
+["apple", "banana", "cherry", "date", "fig", "grape", "honeydew", "kiwi"]

--- a/workflows/engine-showcases/w01-fanout-map-gather/pyproject.toml
+++ b/workflows/engine-showcases/w01-fanout-map-gather/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "w01-fanout-map-gather"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+  # Needs the declarative `map:` construct from horus-runtime's "Dynamic
+  # workflows: fan-out / map / loops" milestone. Until that ships in a
+  # release, install horus-runtime from the milestone branch instead of a
+  # tagged version.
+  "horus-runtime>=0.1.6",
+]

--- a/workflows/engine-showcases/w01-fanout-map-gather/scripts/gather_summary.py
+++ b/workflows/engine-showcases/w01-fanout-map-gather/scripts/gather_summary.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Stage 3 (gather) — aggregate the mapped stage's per-batch folders into one.
+
+The ``score`` task's ``map:`` block runs one clone per batch and writes each
+clone's output under ``score.gathered/<i>/scored/`` (``count.txt`` +
+``upper.txt``). This stage walks that gathered folder, sums the per-batch word
+counts, concatenates the uppercased text, and writes a single combined
+``summary.json`` + ``combined_upper.txt``.
+
+stdlib only.
+
+Usage:
+    gather_summary.py --results score.gathered/ --out results/summary/
+    gather_summary.py --selftest
+"""
+
+from __future__ import annotations  # portable across python3 (>=3.9)
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def collect(results: Path) -> list[dict]:
+    """Read one record per ``<i>/scored/{count,upper}.txt`` under *results*."""
+    batches: list[dict] = []
+    for batch_dir in sorted(
+        (p for p in results.iterdir() if p.is_dir()),
+        key=lambda p: int(p.name) if p.name.isdigit() else p.name,
+    ):
+        scored = batch_dir / "scored"
+        count = int((scored / "count.txt").read_text().split()[0])
+        upper = (scored / "upper.txt").read_text()
+        batches.append({"index": batch_dir.name, "words": count, "upper": upper})
+    return batches
+
+
+def write_summary(batches: list[dict], out: Path) -> int:
+    """Write the combined summary.json + combined_upper.txt into *out*. Returns total words."""
+    out.mkdir(parents=True, exist_ok=True)
+    total = sum(b["words"] for b in batches)
+    (out / "summary.json").write_text(
+        json.dumps(
+            {
+                "total_words": total,
+                "batches": [{"index": b["index"], "words": b["words"]} for b in batches],
+            },
+            indent=2,
+        )
+    )
+    (out / "combined_upper.txt").write_text("".join(b["upper"] for b in batches))
+    return total
+
+
+def run(args: argparse.Namespace) -> int:
+    """Gather all batch results under ``--results`` into ``--out``. Returns total words."""
+    batches = collect(args.results)
+    total = write_summary(batches, args.out)
+    print(f"gather_summary.py: {len(batches)} batch(es), {total} total word(s) -> {args.out}")
+    return total
+
+
+def _selftest() -> None:
+    """Build synthetic gathered batch folders and assert the aggregate."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        results = Path(tmp) / "score.gathered"
+        for i, (word, count) in enumerate([("apple", 1), ("banana", 1), ("cherry pie", 2)]):
+            scored = results / str(i) / "scored"
+            scored.mkdir(parents=True)
+            (scored / "count.txt").write_text(f"{count}\n")
+            (scored / "upper.txt").write_text(word.upper() + "\n")
+
+        out = Path(tmp) / "summary"
+        total = run(argparse.Namespace(results=results, out=out))
+        assert total == 4, total
+
+        data = json.loads((out / "summary.json").read_text())
+        assert data["total_words"] == 4, data
+        assert len(data["batches"]) == 3, data
+
+        combined = (out / "combined_upper.txt").read_text()
+        assert combined == "APPLE\nBANANA\nCHERRY PIE\n", combined
+    print("gather_summary.py selftest: OK")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Aggregate mapped batch results.")
+    parser.add_argument("--results", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        _selftest()
+        return 0
+    if not (args.results and args.out):
+        parser.error("--results and --out are required")
+
+    run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/engine-showcases/w01-fanout-map-gather/scripts/gather_summary.py
+++ b/workflows/engine-showcases/w01-fanout-map-gather/scripts/gather_summary.py
@@ -2,11 +2,11 @@
 """
 Stage 3 (gather) — aggregate the mapped stage's per-batch folders into one.
 
-The ``score`` task's ``map:`` block runs one clone per batch and writes each
-clone's output under ``score.gathered/<i>/scored/`` (``count.txt`` +
-``upper.txt``). This stage walks that gathered folder, sums the per-batch word
-counts, concatenates the uppercased text, and writes a single combined
-``summary.json`` + ``combined_upper.txt``.
+The ``score`` task's ``map:`` block runs one clone per batch; the fan-in sets
+each clone's output path to ``score.gathered/<i>/``, so each clone's ``count.txt``
++ ``upper.txt`` land directly there. This stage walks that gathered folder, sums
+the per-batch word counts, concatenates the uppercased text, and writes a single
+combined ``summary.json`` + ``combined_upper.txt``.
 
 stdlib only.
 
@@ -24,15 +24,19 @@ from pathlib import Path
 
 
 def collect(results: Path) -> list[dict]:
-    """Read one record per ``<i>/scored/{count,upper}.txt`` under *results*."""
+    """Read one record per ``<i>/{count,upper}.txt`` under *results*.
+
+    The ``map:`` fan-in sets each clone's output path directly to
+    ``score.gathered/<i>/``, so the clone's ``scored/`` folder contents land at
+    ``<i>/count.txt`` and ``<i>/upper.txt`` — there is no ``scored/`` sub-level.
+    """
     batches: list[dict] = []
     for batch_dir in sorted(
         (p for p in results.iterdir() if p.is_dir()),
         key=lambda p: int(p.name) if p.name.isdigit() else p.name,
     ):
-        scored = batch_dir / "scored"
-        count = int((scored / "count.txt").read_text().split()[0])
-        upper = (scored / "upper.txt").read_text()
+        count = int((batch_dir / "count.txt").read_text().split()[0])
+        upper = (batch_dir / "upper.txt").read_text()
         batches.append({"index": batch_dir.name, "words": count, "upper": upper})
     return batches
 
@@ -69,10 +73,10 @@ def _selftest() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         results = Path(tmp) / "score.gathered"
         for i, (word, count) in enumerate([("apple", 1), ("banana", 1), ("cherry pie", 2)]):
-            scored = results / str(i) / "scored"
-            scored.mkdir(parents=True)
-            (scored / "count.txt").write_text(f"{count}\n")
-            (scored / "upper.txt").write_text(word.upper() + "\n")
+            batch_dir = results / str(i)
+            batch_dir.mkdir(parents=True)
+            (batch_dir / "count.txt").write_text(f"{count}\n")
+            (batch_dir / "upper.txt").write_text(word.upper() + "\n")
 
         out = Path(tmp) / "summary"
         total = run(argparse.Namespace(results=results, out=out))

--- a/workflows/engine-showcases/w01-fanout-map-gather/scripts/split.py
+++ b/workflows/engine-showcases/w01-fanout-map-gather/scripts/split.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Stage 1 (split) — chunk a small JSON list into batch files.
+
+Reads a JSON array of items and writes one text file per batch (``batch_0.txt``,
+``batch_1.txt``, ...) into the output folder, one item per line. The output
+folder is what the ``score`` task's declarative ``map:`` block fans out over —
+each batch file becomes one item handed to a concurrent clone.
+
+stdlib only.
+
+Usage:
+    split.py --items items.json --out batches/ --batch-size 2
+    split.py --selftest
+"""
+
+from __future__ import annotations  # portable across python3 (>=3.9)
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def split_batches(items: list[str], batch_size: int) -> list[list[str]]:
+    """Chunk *items* into consecutive groups of at most *batch_size*."""
+    if batch_size < 1:
+        raise ValueError("batch_size must be >= 1")
+    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+
+
+def write_batches(batches: list[list[str]], out: Path) -> None:
+    """Write each batch as ``batch_<i>.txt``, one item per line, into *out*."""
+    out.mkdir(parents=True, exist_ok=True)
+    for i, batch in enumerate(batches):
+        (out / f"batch_{i}.txt").write_text("\n".join(batch) + "\n")
+
+
+def run(args: argparse.Namespace) -> int:
+    """Split ``--items`` into batch files under ``--out``. Returns batch count."""
+    items = json.loads(args.items.read_text())
+    if not isinstance(items, list):
+        raise ValueError(f"{args.items} must contain a JSON array")
+    batches = split_batches(items, args.batch_size)
+    write_batches(batches, args.out)
+    print(f"split.py: {len(items)} item(s) -> {len(batches)} batch(es) in {args.out}")
+    return len(batches)
+
+
+def _selftest() -> None:
+    """Split a synthetic item list and assert batch contents."""
+    items = ["a", "b", "c", "d", "e"]
+    batches = split_batches(items, 2)
+    assert batches == [["a", "b"], ["c", "d"], ["e"]], batches
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "batches"
+        write_batches(batches, out)
+        files = sorted(p.name for p in out.glob("batch_*.txt"))
+        assert files == ["batch_0.txt", "batch_1.txt", "batch_2.txt"], files
+        assert out.joinpath("batch_0.txt").read_text() == "a\nb\n"
+        assert out.joinpath("batch_2.txt").read_text() == "e\n"
+    print("split.py selftest: OK")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Split a JSON list into batch files.")
+    parser.add_argument("--items", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        _selftest()
+        return 0
+    if not (args.items and args.out):
+        parser.error("--items and --out are required")
+
+    run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/engine-showcases/w01-fanout-map-gather/scripts/split.py
+++ b/workflows/engine-showcases/w01-fanout-map-gather/scripts/split.py
@@ -2,10 +2,11 @@
 """
 Stage 1 (split) — chunk a small JSON list into batch files.
 
-Reads a JSON array of items and writes one text file per batch (``batch_0.txt``,
-``batch_1.txt``, ...) into the output folder, one item per line. The output
-folder is what the ``score`` task's declarative ``map:`` block fans out over —
-each batch file becomes one item handed to a concurrent clone.
+Reads a JSON array of items and writes one sub-directory per batch
+(``batch_0/data.txt``, ``batch_1/data.txt``, ...) into the output folder, one
+item per line. The output folder is what the ``score`` task's declarative
+``map:`` block fans out over — each batch sub-directory becomes one item, copied
+whole into a concurrent clone as its folder input.
 
 stdlib only.
 
@@ -30,10 +31,17 @@ def split_batches(items: list[str], batch_size: int) -> list[list[str]]:
 
 
 def write_batches(batches: list[list[str]], out: Path) -> None:
-    """Write each batch as ``batch_<i>.txt``, one item per line, into *out*."""
+    """Write each batch as ``batch_<i>/data.txt``, one item per line, into *out*.
+
+    Each batch is its own sub-directory so the ``score`` task's ``map:`` block
+    can fan out over ``out``'s children — the engine hands each clone a *copy of
+    the i-th child directory* as its folder input.
+    """
     out.mkdir(parents=True, exist_ok=True)
     for i, batch in enumerate(batches):
-        (out / f"batch_{i}.txt").write_text("\n".join(batch) + "\n")
+        child = out / f"batch_{i}"
+        child.mkdir(parents=True, exist_ok=True)
+        (child / "data.txt").write_text("\n".join(batch) + "\n")
 
 
 def run(args: argparse.Namespace) -> int:
@@ -58,10 +66,10 @@ def _selftest() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         out = Path(tmp) / "batches"
         write_batches(batches, out)
-        files = sorted(p.name for p in out.glob("batch_*.txt"))
-        assert files == ["batch_0.txt", "batch_1.txt", "batch_2.txt"], files
-        assert out.joinpath("batch_0.txt").read_text() == "a\nb\n"
-        assert out.joinpath("batch_2.txt").read_text() == "e\n"
+        dirs = sorted(p.name for p in out.glob("batch_*") if p.is_dir())
+        assert dirs == ["batch_0", "batch_1", "batch_2"], dirs
+        assert out.joinpath("batch_0", "data.txt").read_text() == "a\nb\n"
+        assert out.joinpath("batch_2", "data.txt").read_text() == "e\n"
     print("split.py selftest: OK")
 
 

--- a/workflows/engine-showcases/w01-fanout-map-gather/workflow.yaml
+++ b/workflows/engine-showcases/w01-fanout-map-gather/workflow.yaml
@@ -1,0 +1,104 @@
+kind: horus_workflow
+name: Fan-out Map Gather Showcase
+tasks:
+  - kind: horus_task
+    id: split
+    name: Split items into batches
+    skip_if_complete: false
+    inputs:
+      - id: items
+        name: items
+        kind: file
+        path: examples/items.json
+    outputs:
+      - id: batches
+        name: batches
+        kind: folder
+        path: batches/
+    executor:
+      kind: shell
+    runtime:
+      kind: python_script
+      script: scripts/split.py
+      python: python3 # stdlib-only; use the target's python3
+      args: --items ${items} --out ${batches} --batch-size 2
+    target:
+      kind: local
+
+  # `score` has no static inputs/outputs of its own: everything about it is
+  # driven by the `map:` block below.
+  #
+  #   over     — which upstream collection to fan out over. `source_task` +
+  #              `source_output` name the producer task/output (here,
+  #              `split`'s `batches` folder); `item_input` is the artifact id
+  #              each clone's template receives its slice under.
+  #   template — the task spec that is cloned once per item in the collection
+  #              (`split`'s output folder has one file per batch, so 4 items
+  #              here -> 4 concurrent clones, `score[00]`..`score[03]`).
+  #   gather   — the downstream task + input artifact id that collects every
+  #              clone's output into one folder for fan-in.
+  #
+  # No explicit `edges:` entry is needed for `split -> score -> gather`: the
+  # `map:` block fully describes both the fan-out and fan-in dependencies and
+  # the loader synthesizes the edges (including the clone -> gather edges,
+  # which are ordering-only / non-transferring since fan-in is via one shared
+  # folder, not per-edge file copies).
+  - kind: horus_task
+    id: score
+    name: Score each batch concurrently
+    map:
+      over:
+        source_task: split
+        source_output: batches
+        item_input: batch
+      template:
+        inputs:
+          - id: batch
+            kind: file
+            path: batch.txt # overwritten per-clone with its slice of `batches/`
+        outputs:
+          - id: scored
+            kind: folder
+            path: scored/
+        runtime:
+          kind: command
+          command: >-
+            mkdir -p $scored &&
+            wc -w < $batch > $scored/count.txt &&
+            tr '[:lower:]' '[:upper:]' < $batch > $scored/upper.txt
+        executor:
+          kind: shell
+        target:
+          kind: local
+      gather:
+        task: gather
+        input: results
+
+  - kind: horus_task
+    id: gather
+    name: Aggregate batch scores into one folder
+    inputs:
+      # Fed by the map's fan-in: one FolderArtifact containing every clone's
+      # `scored/` output under `score.gathered/<i>/`.
+      - id: results
+        name: results
+        kind: folder
+        path: score.gathered/
+    outputs:
+      - id: summary
+        name: summary
+        kind: folder
+        path: results/summary/
+    executor:
+      kind: shell
+    runtime:
+      kind: python_script
+      script: scripts/gather_summary.py
+      python: python3 # stdlib-only; use the target's python3
+      args: --results ${results} --out ${summary}
+    target:
+      kind: local
+
+orchestrator_target:
+  kind: local
+  working_directory: horus_workflow_results

--- a/workflows/engine-showcases/w01-fanout-map-gather/workflow.yaml
+++ b/workflows/engine-showcases/w01-fanout-map-gather/workflow.yaml
@@ -54,8 +54,8 @@ tasks:
       template:
         inputs:
           - id: batch
-            kind: file
-            path: batch.txt # overwritten per-clone with its slice of `batches/`
+            kind: folder
+            path: batch/ # overwritten per-clone with its slice of `batches/`
         outputs:
           - id: scored
             kind: folder
@@ -64,8 +64,9 @@ tasks:
           kind: command
           command: >-
             mkdir -p $scored &&
-            wc -w < $batch > $scored/count.txt &&
-            tr '[:lower:]' '[:upper:]' < $batch > $scored/upper.txt
+            wc -w < $batch/data.txt > $scored/count.txt &&
+            tr '[:lower:]' '[:upper:]' < $batch/data.txt > $scored/upper.txt &&
+            sleep $$(basename $batch)
         executor:
           kind: shell
         target:

--- a/workflows/engine-showcases/w02-programmatic-dynamic-dag/README.md
+++ b/workflows/engine-showcases/w02-programmatic-dynamic-dag/README.md
@@ -1,0 +1,100 @@
+# W-07 · Programmatic Dynamic DAG Showcase
+
+![Domain: Engine Showcases](https://img.shields.io/badge/domain-engine--showcases-orange)
+
+> Requires horus-runtime ≥ the Dynamic-workflows features (milestone: fan-out/map/loops).
+
+## Overview
+
+A minimal demonstration of horus-runtime's runtime DAG-mutation API: a task
+doesn't just consume/produce artifacts, it can **generate the rest of the DAG
+while it's running**, based on data it only sees at execution time. Here,
+`plan` reads a small JSON dataset, discovers how many distinct groups are in
+it, and — from inside its own task function — adds one processing task per
+group plus a fan-in task, none of which existed when the workflow started.
+There is no science and no YAML here (this is the pure-Python builder path);
+the point is the `HorusContext.get_context().workflow` / `add_task` /
+`expand` pattern, which is the mechanism a real pipeline would use for e.g.
+"one task per file format actually present in this upload" or "one task per
+cluster returned by a discovery step" — cases the declarative `map:` block
+(see W-06) can't express because the fan-out isn't over a static collection,
+it's a decision the task itself makes.
+
+## Pipeline
+
+```
+plan                       examples/dataset.json (6 records, 3 groups) ──► (no static output)
+   │  reads the dataset, discovers groups {alpha, beta, gamma}, then AT RUNTIME:
+   │    - adds one process_<group> task per group  (workflow.add_task, one at a time)
+   │    - adds a combine task + all its fan-in edges in one call (workflow.expand)
+   ▼
+process_alpha  process_beta  process_gamma     (generated tasks, run after plan)
+   │  each summarizes its group's records       ──► results/<group>.json
+   └──────────────┬──────────────┘
+                   ▼
+combine                     results/alpha.json + beta.json + gamma.json ──► results/combined.json
+   │  sums count/sum across every generated group task
+```
+
+## Quick start
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+cd workflows/engine-showcases/w02-programmatic-dynamic-dag
+uv sync
+# or: pip install horus-runtime
+
+uv run python run.py
+```
+
+`run.py` is the entrypoint (there's no `workflow.yaml` — the DAG is built and
+mutated entirely in Python). Outputs land in `results/`: one
+`<group>.json` per discovered group plus `combined.json`.
+
+## Inputs / Outputs
+
+**Input** — `examples/dataset.json`: 6 records, each `{"group": ..., "n": ...}`,
+spanning 3 groups (`alpha`: 2 records, `beta`: 3, `gamma`: 1).
+
+**Outputs**
+- `results/<group>.json` — `{"group", "count", "sum", "values"}` for that group.
+- `results/combined.json` — `{"total_count": 6, "total_sum": 30, "per_group": {...}}`
+  for the bundled dataset (`alpha` sum 8, `beta` sum 12, `gamma` sum 10).
+
+## Parameterization
+
+- `examples/dataset.json` — add/remove records or groups; `plan` adapts the
+  number of generated tasks to whatever groups are actually present, with no
+  code changes.
+
+## Implementation notes
+
+- `plan` (`run.py`) is a normal `@FunctionTask.task`; the dynamic part is
+  entirely inside its function body, via `HorusContext.get_context().workflow`
+  — the *running* `BaseWorkflow` instance, reachable from any task's own code.
+- Two mutation entry points are shown side by side: `workflow.add_task(task)`
+  is called once per group (the granular "as tasks are generated" pattern —
+  no edge is needed since each task is created *during* `plan`'s own
+  execution, so it can only run after `plan` completes); `workflow.expand
+  (tasks=[...], edges=[...])` adds the `combine` task together with all of its
+  fan-in edges from the generated `process_<group>` tasks in one call.
+- `combine`'s inputs (`in_<group>`, one per discovered group) aren't known
+  until runtime, so its function signature uses `**kwargs` — the
+  `python_function` runtime's parameter-name injection passes every declared
+  input/output through when a function declares `**kwargs`.
+- Verified against the **current** (pre-milestone) horus-runtime: everything
+  up to and including `plan` reading the dataset and constructing the
+  generated `FunctionTask` objects runs correctly today; it fails exactly
+  (and only) at `workflow.add_task(...)`, since `BaseWorkflow` doesn't have
+  that method yet. That's expected — this showcase targets the milestone
+  branch, not a released version.
+- `add_task`/`add_edge`/`add_artifact`/`expand` signatures here are a best
+  effort based on horus-runtime issue #113 ("Runtime DAG-mutation API");
+  double-check argument names/order against the shipped API once merged.
+
+## References
+
+- horus-runtime milestone: [Dynamic workflows: fan-out / map / loops](https://github.com/temple-compute/horus-runtime/milestone/6)
+- horus-runtime #113 — Runtime DAG-mutation API (add_task/add_edge/expand)

--- a/workflows/engine-showcases/w02-programmatic-dynamic-dag/examples/dataset.json
+++ b/workflows/engine-showcases/w02-programmatic-dynamic-dag/examples/dataset.json
@@ -1,0 +1,8 @@
+[
+  {"group": "alpha", "n": 3},
+  {"group": "alpha", "n": 5},
+  {"group": "beta", "n": 2},
+  {"group": "beta", "n": 4},
+  {"group": "beta", "n": 6},
+  {"group": "gamma", "n": 10}
+]

--- a/workflows/engine-showcases/w02-programmatic-dynamic-dag/pyproject.toml
+++ b/workflows/engine-showcases/w02-programmatic-dynamic-dag/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "w02-programmatic-dynamic-dag"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+  # Needs the Layer-2 DAG-mutation API (add_task/add_edge/expand on a
+  # running BaseWorkflow) from horus-runtime's "Dynamic workflows: fan-out /
+  # map / loops" milestone. Until that ships in a release, install
+  # horus-runtime from the milestone branch instead of a tagged version.
+  "horus-runtime>=0.1.6",
+]

--- a/workflows/engine-showcases/w02-programmatic-dynamic-dag/run.py
+++ b/workflows/engine-showcases/w02-programmatic-dynamic-dag/run.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Programmatic dynamic-DAG showcase.
+
+`plan` is an ordinary `@FunctionTask.task` — but instead of just producing an
+output artifact, it *generates the rest of the DAG at runtime* from the data
+it reads: one `process_<group>` task per distinct group found in
+`examples/dataset.json`, plus a `combine` task that fans them all back in.
+
+This is horus-runtime's Layer-2 DAG-mutation API (milestone: "Dynamic
+workflows: fan-out / map / loops", horus-runtime#113):
+- `HorusContext.get_context().workflow` — the *running* workflow, reachable
+  from inside any task's own code.
+- `workflow.add_task(task)` — inject a new task into the running DAG (used
+  here per group, showing the granular "as tasks are generated" pattern).
+- `workflow.expand(tasks=[...], edges=[...])` — inject a batch of tasks *and*
+  their edges together in one call (used here once, for `combine` plus its
+  fan-in edges from every generated `process_<group>` task).
+
+Requires horus-runtime >= the Dynamic-workflows features (milestone:
+fan-out/map/loops) — `add_task`/`expand` on a running workflow don't exist on
+released horus-runtime yet.
+
+Run:
+    uv run python run.py
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from horus_builtin.artifact.json import JSONArtifact
+from horus_builtin.executor.python_fn import PythonFunctionExecutor
+from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
+from horus_builtin.tui import render_workflow
+from horus_builtin.workflow.horus_workflow import HorusWorkflow
+from horus_runtime.context import HorusContext
+from horus_runtime.core.workflow.edge import WorkflowEdge
+from horus_runtime.logging import horus_logger
+
+HERE = Path(__file__).parent
+DATASET = HERE / "examples" / "dataset.json"
+RESULTS = HERE / "results"
+
+wf = HorusWorkflow(name="programmatic dynamic dag")
+
+
+def _make_process_fn(group: str, records: list[dict[str, Any]]) -> Callable[..., None]:
+    """Build the per-group task function as a closure over its matching records.
+
+    A pure-Python workflow (never round-tripped through YAML) is free to use a
+    closure here; the declarative `map:` template (see W-06) instead requires
+    a *registered*, YAML-serializable function since it must survive
+    `to_yaml`/`from_yaml`.
+    """
+    values = [r["n"] for r in records if r["group"] == group]
+
+    def process(result: JSONArtifact) -> None:
+        """Summarize this group's values into its own result artifact."""
+        result.write({"group": group, "count": len(values), "sum": sum(values), "values": values})
+
+    return process
+
+
+def combine(combined: JSONArtifact, **kwargs: JSONArtifact) -> None:
+    """Fan-in: sum every generated `process_<group>` task's result.
+
+    The inputs are named `in_<group>` and injected via `**kwargs` because the
+    set of groups — and therefore the set of parameter names — is only known
+    once `plan` has read the data at runtime.
+    """
+    per_group: dict[str, dict[str, int]] = {}
+    total_count = 0
+    total_sum = 0
+    for key, artifact in sorted(kwargs.items()):
+        if not key.startswith("in_"):
+            continue
+        data = artifact.read()
+        per_group[key[len("in_") :]] = {"count": data["count"], "sum": data["sum"]}
+        total_count += data["count"]
+        total_sum += data["sum"]
+    combined.write({"total_count": total_count, "total_sum": total_sum, "per_group": per_group})
+
+
+@FunctionTask.task(wf, id="plan", inputs=[JSONArtifact(id="dataset", path=str(DATASET))])
+def plan(dataset: JSONArtifact) -> None:
+    """Read the dataset and expand the DAG: one process_<group> task per
+    distinct group, plus a combine task fanning them all back in."""
+    records = dataset.read()
+    groups = sorted({r["group"] for r in records})
+    horus_logger.log.info(f"plan: found {len(groups)} group(s): {groups}")
+
+    workflow = HorusContext.get_context().workflow
+    assert workflow is not None, "plan must run inside a live HorusContext"
+
+    # --- one process_<group> task per group, added one at a time ---------
+    for group in groups:
+        process_task = FunctionTask(
+            id=f"process_{group}",
+            name=f"process_{group}",
+            runtime=PythonFunctionRuntime(func=_make_process_fn(group, records)),
+            executor=PythonFunctionExecutor(),
+            outputs=[JSONArtifact(id="result", path=str(RESULTS / f"{group}.json"))],
+            target=LocalTarget(),
+        )
+        workflow.add_task(process_task)  # no edge needed: created *during*
+        # plan's own execution, so it can only run after plan completes.
+
+    # --- one combine task, added together with all of its fan-in edges ---
+    combine_task = FunctionTask(
+        id="combine",
+        name="combine",
+        runtime=PythonFunctionRuntime(func=combine),
+        executor=PythonFunctionExecutor(),
+        inputs=[JSONArtifact(id=f"in_{g}", path=str(RESULTS / f"{g}.json")) for g in groups],
+        outputs=[JSONArtifact(id="combined", path=str(RESULTS / "combined.json"))],
+        target=LocalTarget(),
+    )
+    workflow.expand(
+        tasks=[combine_task],
+        edges=[
+            WorkflowEdge(source=f"process_{g}", source_output="result", target="combine", target_input=f"in_{g}")
+            for g in groups
+        ],
+    )
+
+
+def main() -> None:
+    ctx = HorusContext.boot()
+    try:
+        render_workflow(wf, trigger_id="plan")
+        # headless alternative:
+        # import asyncio; asyncio.run(wf.run(trigger_id="plan"))
+    finally:
+        ctx.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/engine-showcases/w02-programmatic-dynamic-dag/run.py
+++ b/workflows/engine-showcases/w02-programmatic-dynamic-dag/run.py
@@ -27,6 +27,9 @@ Run:
 
 from __future__ import annotations
 
+import asyncio
+import random
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -61,7 +64,11 @@ def _make_process_fn(group: str, records: list[dict[str, Any]]) -> Callable[...,
 
     def process(result: JSONArtifact) -> None:
         """Summarize this group's values into its own result artifact."""
-        result.write({"group": group, "count": len(values), "sum": sum(values), "values": values})
+        random_time = random.randint(0, 5)
+        time.sleep(random_time)
+        result.write(
+            {"group": group, "count": len(values), "sum": sum(values), "values": values}
+        )
 
     return process
 
@@ -83,13 +90,23 @@ def combine(combined: JSONArtifact, **kwargs: JSONArtifact) -> None:
         per_group[key[len("in_") :]] = {"count": data["count"], "sum": data["sum"]}
         total_count += data["count"]
         total_sum += data["sum"]
-    combined.write({"total_count": total_count, "total_sum": total_sum, "per_group": per_group})
+    combined.write(
+        {"total_count": total_count, "total_sum": total_sum, "per_group": per_group}
+    )
 
 
-@FunctionTask.task(wf, id="plan", inputs=[JSONArtifact(id="dataset", path=str(DATASET))])
-def plan(dataset: JSONArtifact) -> None:
+@FunctionTask.task(
+    wf,
+    id="plan",
+    inputs=[JSONArtifact(id="dataset", path=DATASET)],
+    skip_if_complete=False,
+)
+async def plan(dataset: JSONArtifact) -> None:
     """Read the dataset and expand the DAG: one process_<group> task per
     distinct group, plus a combine task fanning them all back in."""
+
+    await asyncio.sleep(3)
+
     records = dataset.read()
     groups = sorted({r["group"] for r in records})
     horus_logger.log.info(f"plan: found {len(groups)} group(s): {groups}")
@@ -104,11 +121,14 @@ def plan(dataset: JSONArtifact) -> None:
             name=f"process_{group}",
             runtime=PythonFunctionRuntime(func=_make_process_fn(group, records)),
             executor=PythonFunctionExecutor(),
-            outputs=[JSONArtifact(id="result", path=str(RESULTS / f"{group}.json"))],
+            outputs=[JSONArtifact(id="result", path=RESULTS / f"{group}.json")],
             target=LocalTarget(),
+            skip_if_complete=False,
         )
         workflow.add_task(process_task)  # no edge needed: created *during*
         # plan's own execution, so it can only run after plan completes.
+
+        await asyncio.sleep(2)
 
     # --- one combine task, added together with all of its fan-in edges ---
     combine_task = FunctionTask(
@@ -116,14 +136,20 @@ def plan(dataset: JSONArtifact) -> None:
         name="combine",
         runtime=PythonFunctionRuntime(func=combine),
         executor=PythonFunctionExecutor(),
-        inputs=[JSONArtifact(id=f"in_{g}", path=str(RESULTS / f"{g}.json")) for g in groups],
-        outputs=[JSONArtifact(id="combined", path=str(RESULTS / "combined.json"))],
+        inputs=[JSONArtifact(id=f"in_{g}", path=RESULTS / f"{g}.json") for g in groups],
+        outputs=[JSONArtifact(id="combined", path=RESULTS / "combined.json")],
         target=LocalTarget(),
+        skip_if_complete=False,
     )
     workflow.expand(
         tasks=[combine_task],
         edges=[
-            WorkflowEdge(source=f"process_{g}", source_output="result", target="combine", target_input=f"in_{g}")
+            WorkflowEdge(
+                source=f"process_{g}",
+                source_output="result",
+                target="combine",
+                target_input=f"in_{g}",
+            )
             for g in groups
         ],
     )

--- a/workflows/engine-showcases/w03-loop-map/README.md
+++ b/workflows/engine-showcases/w03-loop-map/README.md
@@ -1,0 +1,87 @@
+# W-08 · Bounded Loop (Range Map) Showcase
+
+![Domain: Engine Showcases](https://img.shields.io/badge/domain-engine--showcases-orange)
+
+> Requires horus-runtime ≥ the Dynamic-workflows features (milestone: fan-out/map/loops).
+
+## Overview
+
+A minimal, deterministic demonstration of horus-runtime's **bounded loop**:
+the same declarative `map:` construct as W-06, but with `range: N` instead of
+an upstream collection — N clones, indices `0..N-1`, no producer task
+required. Each clone squares its own iteration index; a gather stage sums
+them. This is the "run this exact number of times" loop primitive (as
+opposed to the milestone's other loop form, a conditional-repeat
+`LoopController` that keeps injecting the next iteration until a predicate
+says stop — see Implementation notes).
+
+## Pipeline
+
+```
+iterate[00..04] (map, range: 5, 5x concurrent clones, no upstream collection)
+   │  each clone: reads its own iteration index, squares it
+   │  ──► square.txt   (fan-in target: iterate.gathered/<i>/)
+
+gather (local)              iterate.gathered/ (5 subfolders) ──► results/total.txt
+   │  sums every clone's square.txt: 0² + 1² + 2² + 3² + 4² = 30
+```
+
+## Quick start
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+cd workflows/engine-showcases/w03-loop-map
+uv sync
+# or: pip install horus-runtime
+
+horus run workflow.yaml
+```
+
+Outputs land in `horus_workflow_results/`: `iterate.gathered/` (5 subfolders,
+one per clone) and `results/total.txt`, which is `30` for the bundled example.
+
+## Inputs / Outputs
+
+**Input** — none; `range: 5` in `workflow.yaml` is the only "input".
+
+**Outputs**
+- `iterate.gathered/<i>/square.txt` — `i * i` for each clone `i` in `0..4`.
+- `results/total.txt` — the sum of all five squares, `30`.
+
+## Parameterization
+
+- `iterate` task's `map.range` (`workflow.yaml`) — number of iterations /
+  clones. Changing it changes `results/total.txt` predictably: it's the sum
+  of squares `0..N-1`, i.e. `(N-1) * N * (2N-1) / 6`.
+
+## Implementation notes
+
+- `map.range` (no `over:`) is what makes this a **bounded** loop instead of a
+  data-driven fan-out (W-06 uses `over:` to fan out over an upstream
+  collection instead). `index_input: idx` names the template input artifact
+  that each clone's 0-based iteration index is written into — the clone's
+  command reads it from `$idx` and squares it.
+- The milestone also defines a second loop form not shown here: a
+  **conditional-repeat** `LoopController{predicate, body_template,
+  max_iterations}` (horus-runtime #116) that injects the next iteration only
+  if a predicate over the previous iteration's output says to continue,
+  capped by `max_iterations` — a `while`-style loop rather than a fixed
+  `for`-style one. It's a registered task like `MapExpander`, reachable from
+  both YAML and the Python builder, but its exact YAML keyword wasn't
+  settled as of writing, so this showcase sticks to the better-grounded
+  `range:` form. `max_iterations` is the safety bound that keeps a
+  conditional loop from growing the DAG unboundedly.
+- `scripts/sum_squares.py` is stdlib-only and has a `--selftest`
+  (`python scripts/sum_squares.py --selftest`).
+- The exact `map:` field names here (`range`, `index_input`, `gather.task`,
+  `gather.input`) reflect the `MapOver`/`MapExpander` design in horus-runtime
+  issues #113–#116 as of writing; double-check against the released schema
+  if it has since shifted.
+
+## References
+
+- horus-runtime milestone: [Dynamic workflows: fan-out / map / loops](https://github.com/temple-compute/horus-runtime/milestone/6)
+- horus-runtime #116 — Loops: bounded range map + LoopController
+- horus-runtime #115 — Declarative map / fan-out / fan-in (MapExpander)

--- a/workflows/engine-showcases/w03-loop-map/pyproject.toml
+++ b/workflows/engine-showcases/w03-loop-map/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "w03-loop-map"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+  # Needs the bounded range `map:` (range: N, no upstream collection) from
+  # horus-runtime's "Dynamic workflows: fan-out / map / loops" milestone.
+  # Until that ships in a release, install horus-runtime from the milestone
+  # branch instead of a tagged version.
+  "horus-runtime>=0.1.6",
+]

--- a/workflows/engine-showcases/w03-loop-map/scripts/sum_squares.py
+++ b/workflows/engine-showcases/w03-loop-map/scripts/sum_squares.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Stage 2 (gather) — sum the squares produced by a bounded range map.
+
+The `iterate` task's `map:` block runs a fixed number of clones (`range: 5`,
+no upstream collection), one per iteration index `0..4`, each writing its
+index squared to `square.txt`. Clone outputs land under
+`iterate.gathered/<i>/square.txt`. This stage walks that folder and sums them:
+0**2 + 1**2 + 2**2 + 3**2 + 4**2 == 30.
+
+stdlib only.
+
+Usage:
+    sum_squares.py --results iterate.gathered/ --out results/total.txt
+    sum_squares.py --selftest
+"""
+
+from __future__ import annotations  # portable across python3 (>=3.9)
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def collect_squares(results: Path) -> list[int]:
+    """Read one integer per ``<i>/square.txt`` under *results*, in index order."""
+    squares = []
+    for clone_dir in sorted(
+        (p for p in results.iterdir() if p.is_dir()),
+        key=lambda p: int(p.name) if p.name.isdigit() else p.name,
+    ):
+        squares.append(int((clone_dir / "square.txt").read_text().split()[0]))
+    return squares
+
+
+def run(args: argparse.Namespace) -> int:
+    """Sum every clone's square.txt under ``--results`` into ``--out``. Returns the total."""
+    squares = collect_squares(args.results)
+    total = sum(squares)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(f"{total}\n")
+    print(f"sum_squares.py: {squares} -> total {total} -> {args.out}")
+    return total
+
+
+def _selftest() -> None:
+    """Build synthetic gathered clone folders and assert the sum."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        results = Path(tmp) / "iterate.gathered"
+        for i, n in enumerate([0, 1, 4, 9, 16]):
+            clone = results / str(i)
+            clone.mkdir(parents=True)
+            (clone / "square.txt").write_text(f"{n}\n")
+
+        out = Path(tmp) / "results" / "total.txt"
+        total = run(argparse.Namespace(results=results, out=out))
+        assert total == 30, total
+        assert out.read_text().strip() == "30"
+    print("sum_squares.py selftest: OK")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sum a bounded range map's squared outputs.")
+    parser.add_argument("--results", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        _selftest()
+        return 0
+    if not (args.results and args.out):
+        parser.error("--results and --out are required")
+
+    run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/engine-showcases/w03-loop-map/workflow.yaml
+++ b/workflows/engine-showcases/w03-loop-map/workflow.yaml
@@ -1,0 +1,62 @@
+kind: horus_workflow
+name: Bounded Loop Map Showcase
+tasks:
+  # `iterate` has no `over:` — a bounded loop is just `map:` with `range:`
+  # instead of an upstream collection: N clones (`iterate[00]`..`iterate[04]`),
+  # no producer task required. `index_input` names the template input artifact
+  # that receives each clone's 0-based iteration index (here written into a
+  # one-line `idx.txt` the clone's command reads).
+  - kind: horus_task
+    id: iterate
+    name: Square each iteration index (bounded range map)
+    map:
+      range: 5
+      index_input: idx
+      template:
+        inputs:
+          - id: idx
+            kind: file
+            path: idx.txt # populated per-clone with its iteration index
+        outputs:
+          - id: square
+            kind: file
+            path: square.txt
+        runtime:
+          kind: command
+          command: 'n=$(cat $idx); echo $((n * n)) > $square'
+        executor:
+          kind: shell
+        target:
+          kind: local
+      gather:
+        task: gather
+        input: results
+
+  - kind: horus_task
+    id: gather
+    name: Sum the squares
+    inputs:
+      # Fed by the map's fan-in: one FolderArtifact with every clone's
+      # square.txt under iterate.gathered/<i>/.
+      - id: results
+        name: results
+        kind: folder
+        path: iterate.gathered/
+    outputs:
+      - id: total
+        name: total
+        kind: file
+        path: results/total.txt
+    executor:
+      kind: shell
+    runtime:
+      kind: python_script
+      script: scripts/sum_squares.py
+      python: python3 # stdlib-only; use the target's python3
+      args: --results ${results} --out ${total}
+    target:
+      kind: local
+
+orchestrator_target:
+  kind: local
+  working_directory: horus_workflow_results


### PR DESCRIPTION
Closes #4.

Adds three self-contained showcase workflows demonstrating horus-runtime's new dynamic-DAG features (milestone: [Dynamic workflows: fan-out / map / loops](https://github.com/temple-compute/horus-runtime/milestone/6)), under a new `workflows/engine-showcases/` domain. All three are dependency-free (shell/stdlib-only) and deterministic, so they run anywhere in seconds.

- **W-06 · Fan-out / Map / Gather** (`w01-fanout-map-gather`) — a `split` task chunks a small JSON list into batches, a `score` task's declarative `map:` block runs one clone per batch concurrently, and a `gather` task folds the N results back into one folder.
- **W-07 · Programmatic Dynamic DAG** (`w02-programmatic-dynamic-dag`) — a pure-Python workflow where a `plan` task reads a dataset, discovers how many groups it contains, and generates the rest of the DAG at runtime via `HorusContext.get_context().workflow.add_task(...)` / `.expand(...)`.
- **W-08 · Bounded Loop (Range Map)** (`w03-loop-map`) — the same `map:` construct as W-06 but with `range: N` instead of an upstream collection, for a fixed-count deterministic loop.

Each folder has its own README (pipeline diagram, quick start, inputs/outputs, parameterization, implementation notes) and `pyproject.toml`, mirroring the existing `drug-discovery`/`bioexcel_building_blocks` workflows. The root README's workflow table is updated with a new "Engine Showcases" section.

These target the horus-runtime "Dynamic workflows" milestone branches, not a released version — each README says so up front. I validated everything that's possible against the current (pre-milestone) horus-runtime: YAML loads and fails exactly at the unimplemented `map:` field (not from a structural mistake), the Python builder script runs correctly up through `plan` and fails exactly at the not-yet-implemented `workflow.add_task(...)`, and the non-map parts (`split`, and every shell/reduce script standalone) run end-to-end and produce the documented deterministic outputs.