### PR TITLE
Fix workflow definitions so every workflow packages cleanly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ __pycache__/
 
 # uv-lock
 **/uv.lock
+
+# Horus run output
+# Deliberately not ignoring *.zip: these workflows ship committed input data,
+# and a zip is legitimate input. Stray `horus package` output is caught in review.
+horus_workflow_results/
+results/
+horus_resource_report.json
+.horus_conda_env/

--- a/workflows/bioexcel_building_blocks/w06-protein-ligand-docking-cluster90/workflow.yaml
+++ b/workflows/bioexcel_building_blocks/w06-protein-ligand-docking-cluster90/workflow.yaml
@@ -8,7 +8,7 @@ _executor: &executor
   environment_file: conda_env.yaml
 
 _docker_executor: &docker_executor
-  kind: docker_executor
+  kind: docker
   image: quay.io/biocontainers/biobb_vs:5.2.1--pyhdfd78af_0
 
 tasks:

--- a/workflows/bioexcel_building_blocks/w18-molecular-structure-checking/workflow.yaml
+++ b/workflows/bioexcel_building_blocks/w18-molecular-structure-checking/workflow.yaml
@@ -7,6 +7,11 @@ _executor: &executor
   conda: micromamba
   environment_file: conda_env.yaml
 
+# biobb_amber has no osx-arm64 conda build, so its tasks run in a container.
+_docker_executor: &docker_executor
+  kind: docker
+  image: quay.io/biocontainers/biobb_amber:5.2.1--py312hc5e4ab4_0
+
 tasks:
   - kind: horus_task
     id: fetch_pdb

--- a/workflows/drug-discovery/w01-boltz2-virtual-screening/scripts/prep.py
+++ b/workflows/drug-discovery/w01-boltz2-virtual-screening/scripts/prep.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Stage 1 (prep) — build Boltz-2 inputs from a target sequence + ligand library.
+
+Reads a protein FASTA (first record) and a ``.smi`` ligand file, then writes one
+Boltz-2 input YAML per ligand (protein chain A + ligand chain B, with an
+``affinity`` property so Boltz-2 predicts binding) and tars them into a single
+archive. A single-file output is deliberate: Horus SSH transfer is file-based,
+so a tarball is what crosses to the GPU box.
+
+stdlib only — runs unchanged on a local or remote target.
+
+Usage:
+    prep.py --fasta target.fasta --ligands ligands.smi --out boltz_inputs.tar.gz
+    prep.py --selftest
+"""
+
+import argparse
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def read_fasta_sequence(fasta_path: Path) -> str:
+    """Return the concatenated sequence of the first record in *fasta_path*."""
+    seq: list[str] = []
+    started = False
+    for line in fasta_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith(">"):
+            if started:  # second record — stop at the first sequence
+                break
+            started = True
+            continue
+        if line:
+            seq.append(line)
+    sequence = "".join(seq)
+    if not sequence:
+        raise ValueError(f"No sequence found in {fasta_path}")
+    return sequence
+
+
+def read_ligands(smi_path: Path) -> list[tuple[str, str]]:
+    """Parse a ``.smi`` file into ``[(ligand_id, smiles), ...]``.
+
+    Each non-empty line is ``SMILES [name]``; when the name is absent a stable
+    ``lig{n}`` id is assigned. Ids are sanitised for use as filenames.
+    """
+    ligands: list[tuple[str, str]] = []
+    for idx, raw in enumerate(smi_path.read_text().splitlines()):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        smiles = parts[0]
+        name = parts[1] if len(parts) > 1 else f"lig{idx}"
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in name)
+        ligands.append((safe, smiles))
+    if not ligands:
+        raise ValueError(f"No ligands found in {smi_path}")
+    return ligands
+
+
+def boltz_yaml(sequence: str, smiles: str) -> str:
+    """Render a Boltz-2 input YAML for one protein+ligand complex.
+
+    SMILES is emitted as a single-quoted YAML scalar (``'`` doubled) so special
+    characters never break parsing. Hand-rendered to keep this script
+    dependency-free.
+    """
+    smiles_escaped = smiles.replace("'", "''")
+    return (
+        "version: 1\n"
+        "sequences:\n"
+        "  - protein:\n"
+        "      id: A\n"
+        f"      sequence: {sequence}\n"
+        "  - ligand:\n"
+        "      id: B\n"
+        f"      smiles: '{smiles_escaped}'\n"
+        "properties:\n"
+        "  - affinity:\n"
+        "      binder: B\n"
+    )
+
+
+def build_inputs(fasta: Path, ligands: Path, out: Path) -> int:
+    """Write per-ligand YAMLs and tar them to *out*. Returns ligand count."""
+    sequence = read_fasta_sequence(fasta)
+    records = read_ligands(ligands)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp) / "inputs"
+        staging.mkdir()
+        for ligand_id, smiles in records:
+            (staging / f"{ligand_id}.yaml").write_text(
+                boltz_yaml(sequence, smiles)
+            )
+        with tarfile.open(out, "w:gz") as tar:
+            tar.add(staging, arcname="inputs")
+    return len(records)
+
+
+def _selftest() -> None:
+    """Build inputs from a tiny fixture and assert the archive is well-formed."""
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        (d / "t.fasta").write_text(">target\nMVLSPADK\nTNVKAAW\n")
+        (d / "l.smi").write_text("CCO ethanol\nc1ccccc1\n# comment\n")
+        out = d / "boltz_inputs.tar.gz"
+        n = build_inputs(d / "t.fasta", d / "l.smi", out)
+        assert n == 2, n
+        with tarfile.open(out) as tar:
+            names = sorted(tar.getnames())
+            body = tar.extractfile("inputs/ethanol.yaml").read().decode()
+        assert "inputs/ethanol.yaml" in names, names
+        assert "inputs/lig1.yaml" in names, names  # unnamed second ligand
+        assert "sequence: MVLSPADKTNVKAAW" in body, body  # records concatenated
+        assert "smiles: 'CCO'" in body, body
+        assert "binder: B" in body, body
+    print("prep.py selftest: OK")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Boltz-2 inputs.")
+    parser.add_argument("--fasta", type=Path)
+    parser.add_argument("--ligands", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        _selftest()
+        return 0
+    if not (args.fasta and args.ligands and args.out):
+        parser.error("--fasta, --ligands and --out are required")
+
+    n = build_inputs(args.fasta, args.ligands, args.out)
+    print(f"prep.py: wrote {n} Boltz-2 inputs to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/drug-discovery/w01-boltz2-virtual-screening/scripts/rank.py
+++ b/workflows/drug-discovery/w01-boltz2-virtual-screening/scripts/rank.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Stage 3 (rank) — turn Boltz-2 predictions into a ranked shortlist.
+
+Untars the predictions archive produced by the GPU stage, finds every
+``affinity_*.json`` Boltz-2 wrote, joins it with the sibling
+``confidence_*.json``, and writes ``top_hits.csv`` sorted best-first.
+
+Ranking note (see README): Boltz-2's affinity is a reliable *ranking* signal,
+not a calibrated ΔG. We sort by ``affinity_probability_binary`` (descending —
+likelihood the ligand binds), tie-breaking on ``affinity_pred_value``
+(ascending). The absolute numbers are not kcal/mol.
+
+stdlib only.
+
+Usage:
+    rank.py --predictions predictions.tar.gz --out top_hits.csv
+    rank.py --selftest
+"""
+
+import argparse
+import csv
+import json
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def _num(value: object) -> float | None:
+    """Coerce *value* to float, or None if it isn't a number."""
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def collect_hits(pred_dir: Path) -> list[dict[str, object]]:
+    """Scan *pred_dir* for Boltz-2 affinity outputs and return hit rows."""
+    hits: list[dict[str, object]] = []
+    for affinity_file in sorted(pred_dir.rglob("affinity_*.json")):
+        ligand = affinity_file.stem[len("affinity_"):]
+        data = json.loads(affinity_file.read_text())
+
+        # Confidence lives in a sibling confidence_*.json (model 0 if several).
+        confidence: float | None = None
+        siblings = sorted(affinity_file.parent.glob("confidence_*.json"))
+        if siblings:
+            cdata = json.loads(siblings[0].read_text())
+            confidence = _num(cdata.get("confidence_score"))
+
+        hits.append(
+            {
+                "ligand": ligand,
+                "affinity_pred_value": _num(data.get("affinity_pred_value")),
+                "affinity_probability_binary": _num(
+                    data.get("affinity_probability_binary")
+                ),
+                "confidence_score": confidence,
+            }
+        )
+    return hits
+
+
+def _sort_key(hit: dict[str, object]) -> tuple[float, float]:
+    """Best first: highest binder probability, then lowest predicted value."""
+    prob = hit["affinity_probability_binary"]
+    val = hit["affinity_pred_value"]
+    prob_f = prob if isinstance(prob, float) else -1.0
+    val_f = val if isinstance(val, float) else float("inf")
+    return (-prob_f, val_f)
+
+
+def rank(predictions: Path, out: Path) -> int:
+    """Untar *predictions*, rank the hits, write *out* CSV. Returns row count."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        extracted = Path(tmp)
+        with tarfile.open(predictions) as tar:
+            tar.extractall(extracted, filter="data")  # safe extraction
+        hits = collect_hits(extracted)
+
+    hits.sort(key=_sort_key)
+    columns = [
+        "rank",
+        "ligand",
+        "affinity_probability_binary",
+        "affinity_pred_value",
+        "confidence_score",
+    ]
+    with out.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns)
+        writer.writeheader()
+        for i, hit in enumerate(hits, start=1):
+            writer.writerow({"rank": i, **hit})
+    return len(hits)
+
+
+def _selftest() -> None:
+    """Build a fake predictions archive and assert ranking + CSV output."""
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        src = d / "predictions"
+        for name, prob, val in [
+            ("weak", 0.10, -5.0),
+            ("strong", 0.90, -9.0),
+            ("mid", 0.50, -7.0),
+        ]:
+            rec = src / name
+            rec.mkdir(parents=True)
+            (rec / f"affinity_{name}.json").write_text(
+                json.dumps(
+                    {
+                        "affinity_pred_value": val,
+                        "affinity_probability_binary": prob,
+                    }
+                )
+            )
+            (rec / f"confidence_{name}.json").write_text(
+                json.dumps({"confidence_score": prob})
+            )
+        archive = d / "predictions.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(src, arcname=".")
+
+        out = d / "top_hits.csv"
+        n = rank(archive, out)
+        assert n == 3, n
+        rows = list(csv.DictReader(out.open()))
+        order = [r["ligand"] for r in rows]
+        assert order == ["strong", "mid", "weak"], order  # prob descending
+        assert rows[0]["rank"] == "1", rows[0]
+        assert rows[0]["confidence_score"] == "0.9", rows[0]
+    print("rank.py selftest: OK")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Rank Boltz-2 predictions.")
+    parser.add_argument("--predictions", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        _selftest()
+        return 0
+    if not (args.predictions and args.out):
+        parser.error("--predictions and --out are required")
+
+    n = rank(args.predictions, args.out)
+    print(f"rank.py: wrote {n} ranked hits to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

A new `horus package` CLI (horus-runtime, branch `feat/workflow-bundles`) bundles a workflow YAML plus its input files into a zip. Running it across every workflow in this repo surfaced four real data bugs. This PR fixes them so all 25 workflows package cleanly.

## Fixes

**1. `w06-protein-ligand-docking-cluster90` — invalid executor kind**

The executor anchor declared `kind: docker_executor`, which is not a registered kind in the runtime. Changed to `kind: docker`.

**2. `w18-molecular-structure-checking` — missing YAML anchor**

The file used the alias `*docker_executor` (~line 370) but never defined the corresponding anchor, so the YAML would not even parse. Added the missing `_docker_executor: &docker_executor` anchor using `quay.io/biocontainers/biobb_amber:5.2.1--py312hc5e4ab4_0` — the same image the sibling AMBER workflows (w03, w09, w10, w11, w13) use. The failing task runs `leap_gen_top`, a biobb_amber tool, so the image is the right one.

**3. `w01-boltz2-virtual-screening` — restored missing scripts**

`workflow.yaml` references `scripts/prep.py` and `scripts/rank.py`, but the `scripts/` directory was never committed — it was dropped in `46c8bcd` ("First fully working example") when the workflow was rewritten to YAML. This meant the workflow could not run from a fresh clone, and it was the only workflow that failed to package.

Both scripts were restored verbatim from the parent commit `04a06a0`. Their CLI contracts were checked against the current `workflow.yaml` and match exactly:

| script | workflow.yaml `args:` | argparse |
|---|---|---|
| `prep.py` | `--fasta --ligands --out` | `--fasta --ligands --out --selftest` |
| `rank.py` | `--predictions --out` | `--predictions --out --selftest` |

No edits were made to the restored files.

**4. `.gitignore` — ignore Horus run output**

Added `horus_workflow_results/`, `results/`, `horus_resource_report.json`, `.horus_conda_env/`.

Deliberately **not** ignoring `*.zip`: these workflows ship committed input data and a zip is legitimate input. Stray `horus package` output is caught in review instead. There is a comment in the file recording this.

## Verification

There is no CI in this repo, so packaging every workflow against the feature branch of horus-runtime is the safety net:

```
ok=25 fail=0
```

(24/25 before the boltz2 scripts were restored.) No generated zips are committed.

## Notes for reviewers

- **Branch name deviates from `CONTRIBUTING.md`.** The guide prescribes `workflow/wXX-short-description`, which assumes a change scoped to a single workflow. This is a cross-cutting fix spanning three workflows plus repo config, so `fix/workflow-packaging` was used instead.
- Per repo policy this PR requires one human review before merge.