### PR TITLE
Declare advisory resources on representative tasks

### DIFF
--- a/workflows/drug-discovery/w02-autodock-vina-docking/workflow.yaml
+++ b/workflows/drug-discovery/w02-autodock-vina-docking/workflow.yaml
@@ -33,6 +33,10 @@ tasks:
         name: Vina input archive
         path: results/vina_inputs.tar.gz
         kind: file
+
+    resources:
+      cpus: 2
+      memory_gb: 4
     executor:
       kind: conda_python_environment
       conda: micromamba # set to mamba/micromamba if that's what's on PATH
@@ -70,6 +74,12 @@ tasks:
         name: Docking results archive
         path: results/docking_out.tar.gz
         kind: file
+
+    # Advisory only: read by resource-aware targets (Slurm, Terraform) and by
+    # the tc-os dashboard to compare what was asked for against what was used.
+    resources:
+      cpus: 16
+      memory_gb: 32
     executor:
       kind: conda_python_environment
       conda: micromamba # set to mamba/micromamba if that's what's on PATH

--- a/workflows/engine-showcases/w01-fanout-map-gather/workflow.yaml
+++ b/workflows/engine-showcases/w01-fanout-map-gather/workflow.yaml
@@ -75,6 +75,13 @@ tasks:
           kind: shell
         target:
           kind: local
+        # Advisory only: read by resource-aware targets, and compared against
+        # measured usage by the tc-os resources dashboard. Every clone of the
+        # map inherits it, so a generous request here is multiplied by the
+        # fan-out width — which is exactly what right-sizing recovers.
+        resources:
+          cpus: 4
+          memory_gb: 8
       gather:
         task: gather
         input: results


### PR DESCRIPTION
## Why

No workflow in Pantheon declares a `resources:` block — zero hits across all 28. horus-runtime has modelled it for a while (`ResourceRequest{cpus, gpus, memory_gb, vram_gb, walltime}` in `core/resources.py`), and tc-os's new resources dashboard (temple-compute/tc-os#133) uses it as the baseline to compare *measured* usage against.

Without a declared request there is nothing to compare to, so the dashboard correctly shows utilisation only and no right-sizing figure. This gives it something real to work with.

## What

Advisory blocks on three tasks across two workflows:

| Workflow | Task | Requested |
|---|---|---|
| `drug-discovery/w02-autodock-vina-docking` | `prep` | 2 cores, 4 GB |
| `drug-discovery/w02-autodock-vina-docking` | `dock` | 16 cores, 32 GB |
| `engine-showcases/w01-fanout-map-gather` | `score` (map template) | 4 cores, 8 GB |

Deliberately generous relative to what these tasks actually use — the committed `horus_resource_report.json` for w02 has `dock` at **708% CPU / 583 MB peak** — so the gap between requested and measured is visible rather than theoretical. That gap is the point.

On `w01` the block sits inside `map.template`, so every clone of the fan-out inherits it and the over-provisioning is multiplied by the fan-out width.

## Risk

None to execution. `resources` is advisory: resource-aware targets (Slurm, Terraform) read it, and targets that do not understand it ignore it. All three workflows here run on the `local` target, which ignores it entirely. No scripts, no runtimes, no edges touched.

`scripts/seed_pantheon.py` in tc-os needs no change — it packages `workflow.yaml` verbatim.