### PR TITLE
W-28: execution-path coverage harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ features rather than a science domain.
 | W-07 | [Programmatic Dynamic DAG](workflows/engine-showcases/w02-programmatic-dynamic-dag/README.md) | A task generates downstream tasks at runtime from the data it reads, via `add_task`/`expand` |
 | W-08 | [Bounded Loop (Range Map)](workflows/engine-showcases/w03-loop-map/README.md) | Run a fixed number of deterministic iterations with `map: {range: N}` and gather the results |
 | W-27 | [Subworkflow Reuse](workflows/engine-showcases/w04-subworkflow-reuse/README.md) | Inline a child workflow into the parent with `sub:`, reusing one YAML-anchored body across two instances |
+| W-28 | [Execution Path Coverage](workflows/engine-showcases/w05-execution-path-coverage/README.md) | One measurable task per execution mechanism (subprocess, venv, container, in-process) as an acceptance harness for per-task resource measurement |
 
 ## Contributing
 

--- a/workflows/engine-showcases/w05-execution-path-coverage/README.md
+++ b/workflows/engine-showcases/w05-execution-path-coverage/README.md
@@ -1,0 +1,177 @@
+# W-28 · Execution Path Coverage Harness
+
+![Domain: Engine Showcases](https://img.shields.io/badge/domain-engine--showcases-orange)
+
+## Overview
+
+An acceptance harness for **per-task resource measurement**. horus-runtime can
+execute a task in several structurally different ways — a subprocess on the
+target, a subprocess inside a provisioned virtualenv, a container under a
+daemon, or straight inside the orchestrator's own process — and an observer
+that measures one of those does not automatically measure the others. Worse,
+when it doesn't, nothing fails: the task succeeds and the measurement is
+simply absent or zero.
+
+This workflow exercises **every one of those paths**, in one DAG, with an
+identical workload in each: touch ~300 MiB of pages and burn ~4s of CPU. So
+after a run there is exactly one question per task — did the monitor see
+~300 MB and ~100% CPU for ~4s, or not? Anything else is a gap.
+
+Every task also carries an intentionally oversized advisory `resources:` block
+(4 CPUs, 8 GB for a 1-core, 0.3 GB job), so right-sizing has something to
+recover.
+
+## Pipeline
+
+Tasks run one at a time on purpose: two in-process tasks running concurrently
+would land in the same process and make any in-process attribution ambiguous.
+
+```
+shell_command                       ──► results/shell_command.json
+   │  shell executor + command runtime         (subprocess)
+shell_python_script                 ──► results/shell_python_script.json
+   │  shell executor + python_script runtime   (subprocess, script shipped to target)
+uv_environment                      ──► results/uv_environment.json
+   │  uv_python_environment executor           (subprocess inside a uv-built venv)
+python_exec_string                  ──► results/python_exec_string.json
+   │  python executor + python runtime         (IN-PROCESS, exec() of a code string)
+python_function                     ──► results/python_function.json
+   │  python_function executor                 (IN-PROCESS, direct call — run.py only)
+
+workflow.docker.yaml (separate file, needs a Docker daemon)
+docker_container                    ──► stdout only
+   │  docker executor + command runtime        (CONTAINER, under the docker daemon)
+```
+
+Each task writes a stamp JSON recording `sys.executable`, `pid`, allocated
+MiB, CPU iterations and peak RSS, and appends its own label to the `chain`
+list it reads from the previous stamp — so `results/python_function.json`
+lists all five paths and proves the whole DAG ran.
+
+## Quick start
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+cd workflows/engine-showcases/w05-execution-path-coverage
+uv sync
+
+# Four of the five paths (everything expressible in YAML):
+uv run horus run workflow.yaml
+
+# All five, including the in-orchestrator python_function path:
+uv run python run.py
+
+# The container path (needs a running Docker daemon):
+uv sync --extra docker
+uv run horus run workflow.docker.yaml
+```
+
+Outputs land in `horus_workflow_results/results/`.
+
+### Why `run.py` exists
+
+`PythonFunctionRuntime` takes a live Python callable (`func`), so the
+`python_function` executor **cannot be expressed in YAML at all** — a string
+there fails validation with `Input should be callable`. `run.py` loads
+`workflow.yaml`, appends that one task plus its edge with `workflow.expand()`,
+and runs the combined DAG. `workflow.yaml` on its own stays a valid,
+`horus run`-able, sanitize-clean workflow.
+
+## Execution paths and what they map to
+
+| Task | Executor | Runtime | Mechanism | `resource_scope()` |
+|---|---|---|---|---|
+| `shell_command` | `shell` | `command` | subprocess on the target (raw command string) | `ProcessTreeScope` |
+| `shell_python_script` | `shell` | `python_script` | subprocess; script uploaded to the task working dir | `ProcessTreeScope` |
+| `uv_environment` | `uv_python_environment` | `python_script` | subprocess inside a uv-provisioned venv | `ProcessTreeScope` |
+| `python_exec_string` | `python` | `python` | **in-process**: `exec()` on the orchestrator's event loop | `InProcessScope` |
+| `python_function` | `python_function` | `python_function` | **in-process**: the callable is invoked directly | `InProcessScope` |
+| `docker_container` | `docker` | `command` | **container**: workload lives under the Docker daemon, in a different process group from the `docker run` client the runtime spawned | inherits the default `ProcessTreeScope` (of the *client*) |
+
+Two details worth knowing, both of which have bitten someone already:
+
+- The `uv_environment` task deliberately does **not** set `runtime.python`.
+  The environment executor activates the venv and then runs the runtime's
+  interpreter, so leaving the default (`python`) is what routes the script
+  into the venv; pinning `python3` would silently run against the system
+  interpreter and the task would still pass. Check `"python"` in
+  `results/uv_environment.json` — it must point inside
+  `horus_workflow_results/uv_environment/.horus_python_environment/`.
+- The in-process tasks share the orchestrator's pid. Compare `pid` across the
+  stamps: `python_exec_string` and `python_function` are equal to each other
+  and different from every subprocess task.
+
+## Acceptance table — fill this in after a run
+
+Run the workflow with your resource monitor enabled and record what it
+reported per task. Every row should be ~300 MB / ~100% CPU / ~4s; a row that
+isn't is a path the monitor doesn't cover.
+
+| Task | Samples produced? | Peak RAM reported | CPU% reported | Wall (s) | Matches the ~300 MB / ~100% / ~4s workload? |
+|---|---|---|---|---|---|
+| `shell_command` | | | | | |
+| `shell_python_script` | | | | | |
+| `uv_environment` | | | | | |
+| `python_exec_string` | | | | | |
+| `python_function` | | | | | |
+| `docker_container` | | | | | |
+
+Reference run (macOS 15, Apple silicon, `horus-resource-monitor` as of this
+commit) — the point of the harness in one table:
+
+| Task | Reported RAM | Reported CPU% | Wall (s) | Verdict |
+|---|---|---|---|---|
+| `shell_command` | 318.2 MB | 99 | 4.08 | measured |
+| `shell_python_script` | 318.8 MB | 99 | 4.04 | measured |
+| `uv_environment` | 319.1 MB | 97 | 4.17 | measured |
+| `python_exec_string` | 0.0 MB | 0 | 4.02 | **nothing measured** |
+| `python_function` | 0.0 MB | 0 | 4.07 | **nothing measured** |
+| `docker_container` | 27.5 MB | 0 | 6.11 | **wrong process measured** (the `docker run` client, not the 300 MB container) |
+
+The pattern is not a coincidence: that monitor instruments the *target
+command*, so it covers exactly the executors that issue one. The two
+in-process executors never call `target.run_command`, and the docker executor
+calls it for a thin client whose real work is reparented under the daemon.
+
+## Inputs / Outputs
+
+**Input** — none. The first task is self-contained; every later task's input
+is the previous task's stamp.
+
+**Outputs** — `results/<task_id>.json`, one per task:
+
+```json
+{
+  "label": "uv_environment",
+  "python": ".../horus_workflow_results/uv_environment/.horus_python_environment/bin/python",
+  "pid": 94404,
+  "allocated_mb": 300,
+  "cpu_iterations": 10690999,
+  "elapsed_s": 4.03,
+  "peak_rss_mb": 319.1,
+  "chain": ["shell_command", "shell_python_script", "uv_environment"]
+}
+```
+
+## Parameterization
+
+- `--mb` / `--seconds` in `scripts/burn.py`'s invocations (`workflow.yaml`
+  `args:`), and the equivalent literals in the two inline snippets
+  (`shell_command`'s `command:` and `python_exec_string`'s `code:`). Defaults
+  are 300 MiB / 4s per task — big and long enough to be unmistakable in a
+  sampling monitor, small and short enough that the whole harness runs in
+  ~20s.
+- `resources:` blocks — advisory only; nothing enforces them here. They exist
+  so a run has a request to compare measured usage against.
+
+## Notes
+
+- Observed wall time: ~4.1s per task, ~16s for `workflow.yaml`, ~20s for
+  `run.py`, ~6s for the docker task (plus a one-off image pull).
+- The uv venv is built under `horus_workflow_results/uv_environment/` and is
+  reused on later runs; delete `horus_workflow_results/` for a cold run.
+- `workflow.docker.yaml`'s task declares no outputs: `DockerExecutor` mounts
+  nothing by default, so a container cannot write into the task working
+  directory unless you add `volumes:` yourself.

--- a/workflows/engine-showcases/w05-execution-path-coverage/pyproject.toml
+++ b/workflows/engine-showcases/w05-execution-path-coverage/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "w05-execution-path-coverage"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+  "horus-environments>=0.1.2", # uv_python_environment executor
+  "horus-runtime>=0.1.6",
+]
+
+[project.optional-dependencies]
+# Only needed for workflow.docker.yaml, which also needs a running Docker
+# daemon: `uv sync --extra docker`.
+docker = ["horus-docker"]

--- a/workflows/engine-showcases/w05-execution-path-coverage/run.py
+++ b/workflows/engine-showcases/w05-execution-path-coverage/run.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Run the full execution-path coverage harness, including the in-orchestrator
+`python_function` path that `workflow.yaml` cannot express.
+
+`PythonFunctionRuntime` takes a live Python callable (`func`), so there is no
+YAML spelling for it. This script loads `workflow.yaml`, appends the function
+task and its edge, and runs the resulting DAG — every execution path in one
+graph.
+
+Run:
+    uv run python run.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from horus_builtin.artifact.file import FileArtifact
+from horus_builtin.executor.python_fn import PythonFunctionExecutor
+from horus_builtin.runtime.python import PythonFunctionRuntime
+from horus_builtin.target.local import LocalTarget
+from horus_builtin.task.function import FunctionTask
+from horus_runtime.context import HorusContext
+from horus_runtime.core.workflow.base import BaseWorkflow
+from horus_runtime.core.workflow.edge import WorkflowEdge
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE / "scripts"))
+
+from burn import burn, peak_rss_mb  # noqa: E402  (needs the path above)
+
+
+def burn_in_process(prev: FileArtifact, stamp: FileArtifact) -> None:
+    """Same workload as scripts/burn.py, called directly on the event loop.
+
+    No subprocess exists for this task, so anything measured here is the
+    orchestrator's own usage — shared with the runtime itself and with any
+    other task in flight. That is exactly what makes this path the interesting
+    one for a resource monitor.
+    """
+    nbytes, iterations = burn(mb=300, seconds=4.0)
+    with open(prev.path, encoding="utf-8") as fh:
+        chain = json.load(fh).get("chain", [])
+    os.makedirs(os.path.dirname(stamp.path), exist_ok=True)
+    with open(stamp.path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "label": "python_function",
+                "python": sys.executable,
+                "pid": os.getpid(),
+                "allocated_mb": nbytes >> 20,
+                "cpu_iterations": iterations,
+                "peak_rss_mb": round(peak_rss_mb(), 1),
+                "chain": [*chain, "python_function"],
+            },
+            fh,
+            indent=2,
+        )
+
+
+def main() -> None:
+    # Boot first: plugin kinds (`horus_workflow`, `uv_python_environment`, ...)
+    # are registered at boot, so `from_yaml` can't resolve them before it.
+    ctx = HorusContext.boot()
+    try:
+        run(BaseWorkflow.from_yaml(HERE / "workflow.yaml"))
+    finally:
+        ctx.shutdown()
+
+
+def run(wf: BaseWorkflow) -> None:
+    wf.expand(
+        tasks=[
+            FunctionTask(
+                id="python_function",
+                name="Python function executor",
+                description=(
+                    "In-process path — the function is called directly on the "
+                    "orchestrator's event loop."
+                ),
+                runtime=PythonFunctionRuntime(func=burn_in_process),
+                executor=PythonFunctionExecutor(),
+                inputs=[
+                    FileArtifact(
+                        id="prev", path=Path("results/python_exec_string.json")
+                    )
+                ],
+                outputs=[
+                    FileArtifact(
+                        id="stamp", path=Path("results/python_function.json")
+                    )
+                ],
+                target=LocalTarget(),
+                skip_if_complete=False,
+            )
+        ],
+        edges=[
+            WorkflowEdge(
+                source="python_exec_string",
+                source_output="stamp",
+                target="python_function",
+                target_input="prev",
+            )
+        ],
+    )
+
+    asyncio.run(wf.run(trigger_id=wf.tasks[0].id))
+    # TUI alternative:
+    # from horus_builtin.tui import render_workflow
+    # render_workflow(wf, trigger_id=wf.tasks[0].id)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/engine-showcases/w05-execution-path-coverage/scripts/burn.py
+++ b/workflows/engine-showcases/w05-execution-path-coverage/scripts/burn.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Small, measurable workload: hold a few hundred MB, burn CPU for a few seconds.
+
+Deliberately stdlib-only so the exact same file runs unchanged under the
+system interpreter (`shell` executor) and inside a provisioned virtualenv
+(`uv_python_environment` executor). It records `sys.executable` so a reader
+can tell, from the output alone, *which* interpreter actually ran it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import sys
+import time
+
+
+def burn(mb: int, seconds: float) -> tuple[int, int]:
+    """Touch `mb` MiB of pages and spin the CPU for `seconds`.
+
+    Every page is written to, not just allocated: an untouched bytearray is
+    virtual-only on Linux and would never show up in RSS.
+    """
+    buf = bytearray(mb << 20)
+    for i in range(0, len(buf), 4096):
+        buf[i] = 1
+    end = time.monotonic() + seconds
+    iterations = 0
+    while time.monotonic() < end:
+        pow(3, 100_000, 99991)
+        iterations += 1
+    return len(buf), iterations
+
+
+def peak_rss_mb() -> float:
+    """Peak RSS of this process, in MiB (ru_maxrss is bytes on macOS, KiB elsewhere)."""
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return peak / 1024**2 if sys.platform == "darwin" else peak / 1024
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--label", required=True, help="execution path this run exercises")
+    ap.add_argument("--out", required=True, help="where to write the stamp JSON")
+    ap.add_argument("--prev", default=None, help="upstream stamp JSON, if any")
+    ap.add_argument("--mb", type=int, default=300)
+    ap.add_argument("--seconds", type=float, default=4.0)
+    args = ap.parse_args()
+
+    started = time.time()
+    nbytes, iterations = burn(args.mb, args.seconds)
+    elapsed = time.time() - started
+
+    chain = []
+    if args.prev:
+        with open(args.prev, encoding="utf-8") as fh:
+            chain = json.load(fh).get("chain", [])
+
+    stamp = {
+        "label": args.label,
+        "python": sys.executable,
+        "pid": os.getpid(),
+        "allocated_mb": nbytes >> 20,
+        "cpu_iterations": iterations,
+        "elapsed_s": round(elapsed, 2),
+        "peak_rss_mb": round(peak_rss_mb(), 1),
+        "chain": [*chain, args.label],
+    }
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(stamp, fh, indent=2)
+    print(json.dumps(stamp))
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/engine-showcases/w05-execution-path-coverage/workflow.docker.yaml
+++ b/workflows/engine-showcases/w05-execution-path-coverage/workflow.docker.yaml
@@ -1,0 +1,37 @@
+kind: horus_workflow
+name: Execution Path Coverage - Container Path
+# The container execution path, kept out of workflow.yaml so the main harness
+# stays runnable on a machine with no Docker daemon.
+#
+#   uv sync --extra docker
+#   uv run horus run workflow.docker.yaml
+#
+# The task declares no outputs on purpose: DockerExecutor mounts nothing by
+# default, so the container cannot write into the task working directory
+# unless you add `volumes:` yourself. Burning CPU/RAM inside the container is
+# the whole point here — this is the path where the work is NOT in the process
+# tree the runtime spawned (the `docker run` client is), so it is the one most
+# likely to measure nothing at all.
+tasks:
+  - kind: horus_task
+    id: docker_container
+    name: Docker executor + command runtime
+    description: Container path — the workload runs under the Docker daemon, not in the spawned process tree.
+    skip_if_complete: false
+    resources:
+      cpus: 4
+      memory_gb: 8
+      walltime: "00:05:00"
+    executor:
+      kind: docker
+      image: python:3.13-slim
+    runtime:
+      kind: command
+      command: >-
+        python3 -c "import time;b=bytearray(300<<20);[b.__setitem__(i,1) for i in range(0,len(b),4096)];t=time.monotonic()+4;n=sum(1 for _ in iter(lambda: pow(3,100000,99991) if time.monotonic()<t else None, None));print('docker_container ok',len(b)>>20,'MiB',n,'iterations')"
+    target:
+      kind: local
+
+orchestrator_target:
+  kind: local
+  working_directory: horus_workflow_results

--- a/workflows/engine-showcases/w05-execution-path-coverage/workflow.yaml
+++ b/workflows/engine-showcases/w05-execution-path-coverage/workflow.yaml
@@ -1,0 +1,179 @@
+kind: horus_workflow
+name: Execution Path Coverage Harness
+# One task per distinct way horus-runtime can execute work, chained so they run
+# one at a time (overlapping tasks would make in-process measurement ambiguous).
+# Every task does the same job: touch ~300 MiB of pages, burn CPU for ~4s, write
+# a stamp JSON naming the interpreter and pid that did it.
+#
+# The `python_function` executor is NOT here: its runtime takes a live Python
+# callable (`func`), which no YAML can express. That path lives in `run.py`,
+# which loads this file and appends the task. See README.md.
+tasks:
+  - kind: horus_task
+    id: shell_command
+    name: Shell executor + command runtime
+    description: Plain subprocess path — the shell executor runs a literal command string on the target.
+    skip_if_complete: false
+    outputs:
+      - id: stamp
+        name: Shell command stamp
+        kind: file
+        path: results/shell_command.json
+    # Advisory only, and deliberately generous: right-sizing has something to
+    # recover only if the request is bigger than the measured usage.
+    resources:
+      cpus: 4
+      memory_gb: 8
+      walltime: "00:05:00"
+    executor:
+      kind: shell
+    runtime:
+      kind: command
+      # Inline on purpose: a `command` runtime is a raw string, with no script
+      # shipped to the target. `iter(fn, None)` is the sentinel form of a
+      # while-loop, so the whole burn fits on one line.
+      command: >-
+        python3 -c "import json,os,sys,time;b=bytearray(300<<20);[b.__setitem__(i,1) for i in range(0,len(b),4096)];t=time.monotonic()+4;n=sum(1 for _ in iter(lambda: pow(3,100000,99991) if time.monotonic()<t else None, None));os.makedirs(os.path.dirname('${stamp}'),exist_ok=True);json.dump({'label':'shell_command','python':sys.executable,'pid':os.getpid(),'allocated_mb':len(b)>>20,'cpu_iterations':n,'chain':['shell_command']},open('${stamp}','w'),indent=2)"
+    target:
+      kind: local
+
+  - kind: horus_task
+    id: shell_python_script
+    name: Shell executor + python_script runtime
+    description: Subprocess path with a script shipped to the target and run by the target's own interpreter.
+    skip_if_complete: false
+    inputs:
+      - id: prev
+        name: Upstream stamp
+        kind: file
+        path: results/shell_command.json
+    outputs:
+      - id: stamp
+        name: Python script stamp
+        kind: file
+        path: results/shell_python_script.json
+    resources:
+      cpus: 4
+      memory_gb: 8
+      walltime: "00:05:00"
+    executor:
+      kind: shell
+    runtime:
+      kind: python_script
+      script: scripts/burn.py
+      python: python3 # stdlib-only; use the target's python3
+      args: --label shell_python_script --prev ${prev} --out ${stamp}
+    target:
+      kind: local
+
+  - kind: horus_task
+    id: uv_environment
+    name: uv environment executor + python_script runtime
+    description: Subprocess path inside a uv-provisioned virtualenv built on the target before the task runs.
+    skip_if_complete: false
+    inputs:
+      - id: prev
+        name: Upstream stamp
+        kind: file
+        path: results/shell_python_script.json
+    outputs:
+      - id: stamp
+        name: uv environment stamp
+        kind: file
+        path: results/uv_environment.json
+    resources:
+      cpus: 4
+      memory_gb: 8
+      walltime: "00:10:00" # includes building the venv on a cold run
+    executor:
+      kind: uv_python_environment
+      python: "3.13"
+      # No requirements: the venv itself is the point. burn.py is stdlib-only
+      # and reports `sys.executable`, which is the proof it ran inside the venv
+      # rather than against the system interpreter.
+      requirements: []
+    runtime:
+      kind: python_script
+      script: scripts/burn.py
+      # NOTE: no `python:` override here. The environment executor activates the
+      # venv and then runs the runtime's interpreter, so leaving the default
+      # (`python`) is what routes the script through the venv. Pinning
+      # `python3` would silently run outside the environment.
+      args: --label uv_environment --prev ${prev} --out ${stamp}
+    target:
+      kind: local
+
+  - kind: horus_task
+    id: python_exec_string
+    name: Python executor + python code-string runtime
+    description: In-process path — the code string is run with exec() inside the orchestrator, no subprocess at all.
+    skip_if_complete: false
+    inputs:
+      - id: prev
+        name: Upstream stamp
+        kind: file
+        path: results/uv_environment.json
+    outputs:
+      - id: stamp
+        name: Python exec stamp
+        kind: file
+        path: results/python_exec_string.json
+    resources:
+      cpus: 4
+      memory_gb: 8
+      walltime: "00:05:00"
+    executor:
+      kind: python
+    runtime:
+      kind: python
+      # Duplicated from scripts/burn.py on purpose: this runtime ships a string,
+      # not a file, so the snippet has to stand alone.
+      code: |
+        import json, os, sys, time
+
+        buf = bytearray(300 << 20)
+        for i in range(0, len(buf), 4096):
+            buf[i] = 1
+        end = time.monotonic() + 4
+        iterations = 0
+        while time.monotonic() < end:
+            pow(3, 100_000, 99991)
+            iterations += 1
+
+        with open("${prev}", encoding="utf-8") as fh:
+            chain = json.load(fh).get("chain", [])
+        os.makedirs(os.path.dirname("${stamp}"), exist_ok=True)
+        with open("${stamp}", "w", encoding="utf-8") as fh:
+            json.dump(
+                {
+                    "label": "python_exec_string",
+                    "python": sys.executable,
+                    "pid": os.getpid(),
+                    "allocated_mb": len(buf) >> 20,
+                    "cpu_iterations": iterations,
+                    "chain": [*chain, "python_exec_string"],
+                },
+                fh,
+                indent=2,
+            )
+        del buf
+    target:
+      kind: local
+
+edges:
+  - source: shell_command
+    source_output: stamp
+    target: shell_python_script
+    target_input: prev
+  - source: shell_python_script
+    source_output: stamp
+    target: uv_environment
+    target_input: prev
+  - source: uv_environment
+    source_output: stamp
+    target: python_exec_string
+    target_input: prev
+
+orchestrator_target:
+  kind: local
+  working_directory: horus_workflow_results


### PR DESCRIPTION
The acceptance harness for universal task resource measurement. Independent of #12 (branched from `main`; new files only, no overlap).

## Why

We built per-task resource measurement and believed it worked. It worked for *some* execution paths and silently produced nothing for others — silently being the problem. Nothing fails when measurement misses a task: the task succeeds and the numbers are simply absent, so nobody notices.

This workflow exercises **every distinct way horus-runtime can execute a task** in one DAG, so the question "did measurement work?" has a per-path answer you can read off a table.

## What it runs

`workflows/engine-showcases/w05-execution-path-coverage/` — 4 YAML tasks plus a 5th added programmatically, and the container path in a separate file so the main harness needs no daemon:

| Task | Executor + runtime | Mechanism |
|---|---|---|
| `shell_command` | `shell` + `command` | local subprocess |
| `shell_python_script` | `shell` + `python_script` | local subprocess |
| `uv_environment` | `uv_python_environment` + `python_script` | subprocess inside a built venv |
| `python_exec_string` | `python` + code string | **in-process** `exec()` |
| `python_function` (via `run.py`) | `python_function` | **in-process** call |
| `docker_container` (separate file) | `docker` | container under the daemon |

Each task touches 300 MiB and burns ~4s of CPU, then writes a stamp JSON recording `sys.executable`, `pid`, allocated MiB and peak RSS, extending a `chain` from its upstream — so you can prove *which interpreter and which process* actually ran, not just that the task passed.

Tasks run sequentially on purpose: concurrent in-process tasks share the orchestrator, which would make in-process attribution ambiguous and the harness useless as evidence.

Every task carries a deliberately oversized advisory `resources:` block so right-sizing has something to recover.

## The result it captured

Run under the current resource monitor, all six paths green, the harness produced exactly the evidence it exists for:

| Task | RAM | CPU% | Verdict |
|---|---|---|---|
| `shell_command` | 318.2 MB | 99 | measured |
| `shell_python_script` | 318.8 MB | 99 | measured |
| `uv_environment` | 319.1 MB | 97 | measured |
| `python_exec_string` | 0.0 MB | 0 | **nothing measured** |
| `python_function` | 0.0 MB | 0 | **nothing measured** |
| `docker_container` | 27.5 MB | 0 | **wrong process** — the `docker run` client, not the 300 MB container |

Root cause: the monitor hooks `horus.middleware.target_command`, so it only sees work that goes through `target.run_command`. The two in-process executors never call it. Docker calls it for the *client*, whose 27.5 MB is what got measured while the workload ran under the daemon in another process group.

## Verification

Every path actually executed on a real machine — nothing skipped, nothing mocked. `workflow.yaml` alone: 16.3s. With `run.py`: 20.4s. Docker adds 6.1s plus a one-off image pull. Sanitize check clean on both YAML files.

## Two gaps this surfaced

- **`python_function` is not expressible in YAML at all.** `PythonFunctionRuntime.func` is a pydantic `Callable` field, and a dotted-path string fails validation with `Input should be callable`. That is why this path needs `run.py`. It means the function path cannot be packaged, sanitized, or imported into tc-os — worth a `str → callable` resolver on that field.
- **Silent misconfiguration in `uv_python_environment`:** setting `runtime.python: python3` (which every sibling workflow does for `shell` tasks) runs the script against the *system* interpreter, outside the venv, and the task still passes. The default `python` is what routes into the venv. The harness leaves it defaulted and its stamp's `sys.executable` proves which ran; both the YAML and README call this out.