### PR TITLE
fix(w02): call meeko via -m instead of its console script

### DIFF
--- a/workflows/drug-discovery/w02-autodock-vina-docking/scripts/prep.py
+++ b/workflows/drug-discovery/w02-autodock-vina-docking/scripts/prep.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations  # portable across python3 (>=3.9)
 
 import argparse
+import importlib.util
 import json
 import shutil
 import subprocess
@@ -195,7 +196,9 @@ def prepare_ligands(ligands: Path, staging: Path) -> int:
             print(f"prep.py: embedded {n} SMILES to 3D")
         _run(
             [
-                "mk_prepare_ligand.py",
+                # Not the console script: its /bin/sh shim execs an unquoted
+                # interpreter path, which breaks when the env dir has a space.
+                sys.executable, "-m", "meeko.cli.mk_prepare_ligand",
                 "-i", str(sdf),
                 "--multimol_outdir", str(lig_dir),
             ]
@@ -330,9 +333,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if not (args.receptor and args.ligands and args.out):
         parser.error("--receptor, --ligands and --out are required")
-    for tool in ("obabel", "mk_prepare_ligand.py"):
-        if shutil.which(tool) is None:
-            parser.error(f"'{tool}' not on PATH — run inside the stage's uv env")
+    if shutil.which("obabel") is None:
+        parser.error("'obabel' not on PATH — run inside the stage's uv env")
+    if importlib.util.find_spec("meeko.cli.mk_prepare_ligand") is None:
+        parser.error("meeko not importable — run inside the stage's uv env")
 
     build_inputs(args)
     return 0


### PR DESCRIPTION
## Problem

The `prep` stage of the AutoDock Vina docking workflow fails with exit code 126:

```
mk_prepare_ligand.py: line 2: /Users/cdominguez/Downloads/AutoDock: No such file or directory
mk_prepare_ligand.py: line 2: exec: /Users/cdominguez/Downloads/AutoDock: cannot execute: No such file or directory
subprocess.CalledProcessError: Command '['mk_prepare_ligand.py', ...]' returned non-zero exit status 126.
```

Meeko installs `mk_prepare_ligand.py` as a `/bin/sh` shim whose second line is:

```sh
'''exec' /path/to/.horus_python_environment/bin/python "$0" "$@"
```

The interpreter path is unquoted, so any space in the environment's path makes the shell split it. Running the workflow from a directory such as `AutoDock Vina Docking` therefore breaks every ligand preparation.

## Fix

Invoke the module through the running interpreter, `sys.executable -m meeko.cli.mk_prepare_ligand`, which bypasses the shim entirely. The `shutil.which("mk_prepare_ligand.py")` preflight is replaced with an `importlib.util.find_spec` check since there is no longer a script on PATH to look for.

## Verification

Ran end to end from a path containing spaces, using the stage's own conda environment:

```
prep.py: embedded 3 SMILES to 3D
PDBQT files written: 3
prep.py: wrote 3 ligand(s) + receptor + box to vina_inputs.tar.gz
```

`prep.py --selftest` also passes.