### PR TITLE
Added engin workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ uv run horus run workflow.yaml
 | W-28 | [LLM From Scratch - Pretrain, SFT & Eval](workflows/ai/w01-train-llm/README.md) | Clone a from-scratch Transformer repo, tokenize Pile/instruction data, pretrain, SFT, and evaluate GSM8K accuracy |
 | W-29 | [Tiny LLM From Scratch - TinyStories Pretrain & Sample](workflows/ai/w02-tiny-llm/README.md) | Pretrain a small from-scratch Transformer on TinyStories (not the 900GB Pile) and sample a generated story |
 
+### Omics
+
+| ID | Workflow | Description |
+|---|---|---|
+| W-33 | [Engin Strain-to-Scale](workflows/omics/w01-engin-strain-to-scale/README.md) | Which host, which route, and what to run next for a bioprocess target, via Engin's three independent decision-aid CLIs, merged into one calibrated decision brief |
+
 ### Engine Showcases
 
 Small, self-contained workflows that demonstrate horus-runtime engine

--- a/workflows/omics/w01-engin-strain-to-scale/README.md
+++ b/workflows/omics/w01-engin-strain-to-scale/README.md
@@ -1,0 +1,156 @@
+# W-33 · Engin Strain-to-Scale
+
+![Domain: Omics](https://img.shields.io/badge/domain-omics-blue)
+
+## Overview
+
+[Engin](https://github.com/enginbio/engin-suite) is a three-question decision
+aid for early bioprocess development: given a molecule you want to make, it
+answers *which host?* (`engin-host`), *which route?* (`engin-pathway`), and
+*what to run next?* (`engin-process`), each with a calibrated 90% confidence
+band rather than a bare number. It is a library, not a framework -- three
+small CLIs that each read one `project.yaml` and print an answer.
+
+**The three stages are independent.** Each reads `project.yaml` and answers
+its own question; none consumes another's output. So this workflow is one
+input artifact fanning out to three parallel tasks, not a pipeline, with a
+fourth `summary` task that merges the three answers into one decision brief.
+
+This is deliberately not an HPC workload: each stage runs in under a couple
+of seconds on 1 CPU (scikit-learn / scipy, no PyTorch, no cluster). Its value
+here is as the cheap upstream step that decides what an expensive downstream
+run (docking, MD, screening) should even be pointed at.
+
+Engin is early, and honest about it: measured against 406 real industrial
+fermentation batches, its interval coverage lands near the nominal 90% while
+its point predictions collapse to near-uselessness (R² ≈ 0.02-0.11). This
+workflow's `summary` stage keeps that posture (intervals, "illustrative" /
+"synthetic" / "judgement" flags) in the merged brief rather than smoothing it
+away into three confident numbers -- see **How to read this** in
+`summary.md`.
+
+## Pipeline
+
+```
+                              project.yaml
+                    ┌──────────────┼──────────────┐
+                    ▼              ▼              ▼
+              host (chassis)  pathway (route)  process (next runs)
+              uv env: engin-  uv env: engin-   uv env: engin-host[cli]
+              host[cli]       pathway[cli]     (pulls in engin-core)
+                    │              │              │
+                    └──────────────┼──────────────┘
+                                   ▼
+                          summary (shell, stdlib)
+                          results/summary.{json,md}
+```
+
+`host`, `pathway` and `process` run concurrently; `summary` waits on all
+three. `summary` is listed first in `workflow.yaml`'s `tasks:` even though it
+depends on the other three -- see the comment there: `horus run` with no
+`--trigger` defaults to `tasks[0]`, and `summary` is the only task whose
+ancestors cover the whole graph, since host/pathway/process share no
+task-to-task edge with each other.
+
+## Quick start
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install horus-runtime and the environments plugin
+uv sync
+# or: pip install horus-runtime horus-environments
+
+# Run the workflow
+uv run horus run workflow.yaml
+```
+
+All four tasks run locally; `host`, `pathway` and `process` each provision
+their own `uv`-managed virtualenv per the `horus-environments` plugin, so
+nothing needs to be hand-built. `summary` is stdlib-only Python, run directly
+by the target's `python3`.
+
+Outputs land in `horus_workflow_results/results/`: `host.{json,txt}`,
+`pathway.{json,txt}`, `process.{json,txt}`, and `summary.{json,md}`.
+
+## Inputs / Outputs
+
+**Input:** `examples/project.yaml` -- one file, read by all three stages.
+Every section is optional; generate a fresh commented starter with
+`engin-host --init project.yaml`.
+
+**Outputs** (all under `horus_workflow_results/results/`)
+- `host.json` / `host.txt` -- ranked host organisms, `engin-host`'s
+  recommendation and its 90% band.
+- `pathway.json` / `pathway.txt` -- ranked biosynthetic routes with
+  manufacturability intervals.
+- `process.json` / `process.txt` -- current best cost and the next runs to
+  try, ranked by expected cost reduction.
+- `summary.json` / `summary.md` -- the three answers merged into one
+  decision brief, keeping every interval and caveat.
+
+`examples/expected-output/` bundles a captured run of the CLIs directly
+against the example `project.yaml` (`seed: 0`, so `engin-pathway` and
+`engin-process` are deterministic) -- a reference for the shape of the JSON
+and the numbers, not a fixture this workflow diffs against (see
+Implementation Notes).
+
+## Parameterization
+
+Everything a user would change lives in `examples/project.yaml`:
+
+| Section | Knob | Default |
+|---|---|---|
+| `host.weights` / `host.hard` | capability weights and non-negotiable minimums | secretion/titer 1.0, scaleup/cost 0.7; secretion hard-min 0.40 |
+| `pathway.routes` | candidate routes, each step scored 0-1 (entered by hand) | route-A (2 steps), route-B (3 steps) |
+| `process.reactor` | vessel geometry and run length | 1 L → 2.5 L, 48 h, 0.2 g/L inoculum |
+| `process.cost` | substrate price, vessel occupancy, downstream cost, target $/kg | target `$200/kg` |
+| `process.batch_size` / `seed` | how many runs to recommend; reproducibility | 4 runs, `seed: 0` |
+| `host`/`pathway`/`process` executor `requirements` | pinned Engin version | `==0.1.1` |
+
+## Implementation Notes
+
+**Why three parallel tasks, not a pipeline.** Nothing computed by one stage
+feeds another -- see Overview. Fanning out from one artifact is both the
+honest shape of the science and the fastest way to run it.
+
+**Why `process` installs `engin-host[cli]`, not `engin-core[cli]`.**
+`engin-process` ships inside `engin-core`, but only `engin-host` and
+`engin-pathway` publish a `[cli]` extra (which pulls in `pyyaml` for reading
+`project.yaml`); `engin-host[cli]` transitively pulls in `engin-core[cli]`,
+so it is the smallest pinned requirement that gets `engin-process` a working
+CLI.
+
+**The bundled `examples/expected-output/` was captured from a development
+checkout of `engin-suite`, not the published `0.1.1` wheel.** Running this
+workflow against PyPI's `engin-host==0.1.1` reproduces `pathway.json` and
+`process.json` numerically (to floating-point noise) and `pathway.txt` /
+`process.txt` verbatim, but `host.json` / `host.txt` from the live package
+omit the "EFSA QPS status" section and the per-row `capability_profile` /
+`qps` fields the bundled example shows (it instead carries an `unsourced`
+list). `scripts/summary.py` only reads fields present in both shapes
+(`decision.*`, `ranking[0].provenance`, `ranking[0].flags`), so `summary.md`
+is unaffected either way; re-pin the `host` task's requirement once a PyPI
+release ships the QPS feature if you want it in the brief.
+
+## Open questions
+
+(Carried over from Engin's own README, which flags these rather than
+resolving them.)
+
+- **Which stages to expose first for a UI.** `engin-process` tells the most
+  self-contained story (one number, a target, a plan); `engin-host` and
+  `engin-pathway` need their caveats surfaced to be read correctly.
+- **Real data in.** The biggest upgrade is a user supplying ≥ 40 real routes
+  or real run history, at which point `engin-pathway` and `engin-process`
+  stop reasoning about a synthetic world.
+
+## References
+
+- Engin suite -- <https://github.com/enginbio/engin-suite> · docs
+  <https://docs.engin.bio>
+- Real-data calibration (the honest numbers) --
+  <https://github.com/enginbio/engin-suite/blob/main/docs/methods/real-data-calibration.md>
+- API stability (pin exact versions pre-1.0) --
+  <https://github.com/enginbio/engin-suite/blob/main/docs/api-stability.md>

--- a/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-host.json
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-host.json
@@ -1,0 +1,146 @@
+{
+  "target": "recombinant lipase (secreted enzyme)",
+  "decision": {
+    "host": "P. pastoris",
+    "feasible": true,
+    "score": 0.8294117647058824,
+    "band90": 0.06852446980058381,
+    "confidence": 0.6810662159538993,
+    "key_drivers": [
+      "secretion",
+      "titer",
+      "scaleup"
+    ],
+    "alternatives": [
+      "B. subtilis",
+      "S. cerevisiae",
+      "CHO (mammalian)"
+    ],
+    "capability_profile": {
+      "secretion": 0.85,
+      "glyco": 0.5,
+      "titer": 0.85,
+      "speed": 0.6,
+      "tools": 0.75,
+      "scaleup": 0.8,
+      "cost": 0.8,
+      "smallmol": 0.6,
+      "protein": 0.85
+    }
+  },
+  "ranking": [
+    {
+      "host": "P. pastoris",
+      "score": 0.8294117647058824,
+      "sd": 0.0416562126447318,
+      "band90": 0.06852446980058381,
+      "contributions": [
+        [
+          "secretion",
+          0.25
+        ],
+        [
+          "titer",
+          0.25
+        ],
+        [
+          "scaleup",
+          0.16470588235294117
+        ]
+      ],
+      "flags": [],
+      "feasible": true,
+      "provenance": "illustrative",
+      "qps": {
+        "status": "listed",
+        "taxonomic_unit": "Komagataella phaffii",
+        "qualifications": [],
+        "source": "2026-efsa-qps-list",
+        "note": "Listed with no qualification, which is why `qualifications` is empty rather than absent -- the empty list is the fact. Filed under the current name; 'P. pastoris' is this KB's colloquial label for the same species."
+      },
+      "unsourced": [
+        "cost",
+        "scaleup",
+        "secretion",
+        "titer"
+      ]
+    },
+    {
+      "host": "B. subtilis",
+      "score": 0.7999999999999999,
+      "sd": 0.04657732761866964,
+      "band90": 0.07661970393271156,
+      "contributions": [
+        [
+          "secretion",
+          0.2647058823529412
+        ],
+        [
+          "titer",
+          0.20588235294117646
+        ],
+        [
+          "cost",
+          0.175
+        ]
+      ],
+      "flags": [],
+      "feasible": true,
+      "provenance": "illustrative",
+      "qps": {
+        "status": "listed",
+        "taxonomic_unit": "Bacillus subtilis",
+        "qualifications": [
+          "The strains should not harbour any acquired antimicrobial resistance genes to clinically relevant antimicrobials."
+        ],
+        "source": "2026-efsa-qps-list",
+        "note": ""
+      },
+      "unsourced": [
+        "cost",
+        "scaleup",
+        "secretion",
+        "titer"
+      ]
+    },
+    {
+      "host": "S. cerevisiae",
+      "score": 0.7176470588235293,
+      "sd": 0.029932702776423816,
+      "band90": 0.04923929606721718,
+      "contributions": [
+        [
+          "titer",
+          0.22058823529411764
+        ],
+        [
+          "scaleup",
+          0.175
+        ],
+        [
+          "cost",
+          0.175
+        ]
+      ],
+      "flags": [],
+      "feasible": true,
+      "provenance": "illustrative",
+      "qps": {
+        "status": "listed",
+        "taxonomic_unit": "Saccharomyces cerevisiae",
+        "qualifications": [
+          "When used as active agents (viable cells): Absence of resistance to antimycotics used for medical treatment of yeast infections in cases where viable cells are added to the food or feed chain."
+        ],
+        "source": "2026-efsa-qps-list",
+        "note": ""
+      },
+      "unsourced": [
+        "cost",
+        "scaleup",
+        "secretion",
+        "titer"
+      ]
+    }
+  ],
+  "kb_provenance": "illustrative"
+}

--- a/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-host.txt
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-host.txt
@@ -1,0 +1,29 @@
+# Host recommendation — recombinant lipase (secreted enzyme)
+_engin-host first-slice. Some capability values are **illustrative** -- hand-assigned, not sourced. Score in [0,1]; ± is a 90% band from KB confidence, which is a separate question from whether the value was sourced._
+
+| rank | host | score (90% band) | top drivers | flags | basis |
+|---|---|---|---|---|---|
+| 1 | P. pastoris | 0.83 ± 0.07 | secretion 0.25, titer 0.25, scaleup 0.16 | — | illustrative |
+| 2 | B. subtilis | 0.80 ± 0.08 | secretion 0.26, titer 0.21, cost 0.17 | — | illustrative |
+| 3 | S. cerevisiae | 0.72 ± 0.05 | titer 0.22, scaleup 0.17, cost 0.17 | — | illustrative |
+
+## EFSA QPS status (displayed, not scored)
+
+_QPS covers microorganisms **intentionally added to food or feed**. It does not speak to an enzyme, a pharmaceutical intermediate or a material, which is what most of these hosts are used for. `excluded` means assessed and refused; `out_of_scope` means the scheme never reached it. The two are not points on one scale, and neither affects the ranking above._
+
+- **P. pastoris** (Komagataella phaffii) — `listed`
+- **B. subtilis** (Bacillus subtilis) — `listed`
+  - qualification: The strains should not harbour any acquired antimicrobial resistance genes to clinically relevant antimicrobials.
+- **S. cerevisiae** (Saccharomyces cerevisiae) — `listed`
+  - qualification: When used as active agents (viable cells): Absence of resistance to antimycotics used for medical treatment of yeast infections in cases where viable cells are added to the food or feed chain.
+
+**Recommendation:** P. pastoris (score 0.83 ± 0.07). Driven by secretion, titer, scaleup. No hard-constraint conflicts.
+
+**This recommendation rests on unsourced values.** 4 of the capabilities it weighs are illustrative: cost, scaleup, secretion, titer. Treat the ranking as a demonstration of the scoring machinery rather than as evidence about these organisms.
+
+
+confidence: 0.68  — P(P. pastoris really is the best feasible host here)
+
+The capability knowledge base is illustrative: 60 hand-assigned values
+with no citations behind them (issue #146). Treat this as a structured
+way to argue about the choice, not as evidence for it.

--- a/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-pathway.json
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-pathway.json
@@ -1,0 +1,19 @@
+{
+  "target": "recombinant lipase (secreted enzyme)",
+  "ranking": [
+    {
+      "route_id": "route-A",
+      "manufacturability": 0.6430937906428049,
+      "lo": 0.5319574436285082,
+      "hi": 0.7542301376571017
+    },
+    {
+      "route_id": "route-B",
+      "manufacturability": 0.6356324510475709,
+      "lo": 0.5244961040332741,
+      "hi": 0.7467687980618678
+    }
+  ],
+  "trained_on": "synthetic generator",
+  "n_labelled_supplied": 0
+}

--- a/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-pathway.txt
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-pathway.txt
@@ -1,0 +1,21 @@
+target: recombinant lipase (secreted enzyme)
+
+rank  route                     manufacturability  90% interval
+   1  route-A                               0.643  [0.532, 0.754]
+   2  route-B                               0.636  [0.524, 0.747]
+
+The intervals for route-A and route-B overlap, so this
+ranking does not separate them. Treat the order as a shortlist, not a winner.
+
+  !! The model was trained on this package's own synthetic route
+     generator, not on real routes — you supplied 0 measured
+     route(s) and 40 are needed to train on your own data.
+     Its published margin over step-count may be an artifact of that
+     generator (issue #124). The step features you entered are also your
+     own judgement: nothing computes them from structure yet (issue #140).
+     This orders your routes by a model of a different world. Read it as
+     a prompt for discussion, not as a measurement.
+
+--- stderr (calibration note) ---
+/tmp/engin-suite/packages/engin-graph/src/engin_graph/rank.py:51: UserWarning: calibration set of 40 gives a 90% interval whose true coverage lies in roughly [0.82, 0.97] (central 90%, Beta(n+1-l, l)). The multiplier is honest on average and noisy here. Pass `warn_below_slack=None` to silence, or see `conformal_coverage_interval` for the size you need.
+  self.q = split_conformal_multiplier(y, mean, sd, level=level)

--- a/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-process.json
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-process.json
@@ -1,0 +1,74 @@
+{
+  "target": "recombinant lipase (secreted enzyme)",
+  "objective": "net_usd_per_kg",
+  "best_known": {
+    "expected_usd_per_kg": 49.891107452020826,
+    "lower_usd_per_kg": 47.385925194275,
+    "upper_usd_per_kg": 52.48347150975536,
+    "prob_meets_target": 1.0,
+    "target_usd_per_kg": 200.0
+  },
+  "recommended": [
+    {
+      "expected_cost_reduction_usd_per_kg": 2.9151771846104833,
+      "feed_rate": 0.05849273816368147,
+      "feed_start": 4.253315472555707,
+      "Sf": 446.71369759655573,
+      "induction_time": 8.400898280211965,
+      "S0": 21.22810164183729
+    },
+    {
+      "expected_cost_reduction_usd_per_kg": 2.387831631677855,
+      "feed_rate": 0.05119081487143104,
+      "feed_start": 3.25968678740443,
+      "Sf": 438.604638122176,
+      "induction_time": 8.234218319327393,
+      "S0": 28.918806308408985
+    },
+    {
+      "expected_cost_reduction_usd_per_kg": 1.7713244072095342,
+      "feed_rate": 0.058636863973143764,
+      "feed_start": 4.020701378560345,
+      "Sf": 425.3718316406897,
+      "induction_time": 9.428740326993351,
+      "S0": 6.947177527475832
+    },
+    {
+      "expected_cost_reduction_usd_per_kg": 1.7538664668851782,
+      "feed_rate": 0.05706489525672136,
+      "feed_start": 5.054420597914456,
+      "Sf": 430.2582170673539,
+      "induction_time": 7.360646667344232,
+      "S0": 27.131125068801584
+    }
+  ],
+  "reactor": {
+    "v0": 1.0,
+    "vmax": 2.5,
+    "t_end": 48.0,
+    "dt": 0.05,
+    "x0": 0.2,
+    "knob_bounds": {
+      "feed_rate": [
+        0.0,
+        0.06
+      ],
+      "feed_start": [
+        3.0,
+        20.0
+      ],
+      "Sf": [
+        150.0,
+        450.0
+      ],
+      "induction_time": [
+        3.0,
+        26.0
+      ],
+      "S0": [
+        5.0,
+        30.0
+      ]
+    }
+  }
+}

--- a/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-process.txt
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/expected-output/engin-process.txt
@@ -1,0 +1,18 @@
+target: recombinant lipase (secreted enzyme)
+vessel: 1 L -> 2.5 L over 48 h   (40 simulated runs)
+
+best cost so far : $50/kg  [$47, $52] (90%)
+clears $200/kg target with probability 1.00
+
+next 4 runs, by expected cost reduction:
+  1. E[saving]=$3/kg   feed_rate=0.0585  feed_start=4.25  Sf=447  induction_time=8.4  S0=21.2
+  2. E[saving]=$2/kg   feed_rate=0.0512  feed_start=3.26  Sf=439  induction_time=8.23  S0=28.9
+  3. E[saving]=$2/kg   feed_rate=0.0586  feed_start=4.02  Sf=425  induction_time=9.43  S0=6.95
+  4. E[saving]=$2/kg   feed_rate=0.0571  feed_start=5.05  Sf=430  induction_time=7.36  S0=27.1
+
+Optimizes net $/kg rather than titer (D13), so it will look worse than a
+titer-chasing tool on the number most teams report — that is the intended
+trade, and --titer runs the comparison.
+
+It cannot read your actual run history yet: the runs above were simulated
+from the vessel in your project file, so this is only as good as that model.

--- a/workflows/omics/w01-engin-strain-to-scale/examples/project.yaml
+++ b/workflows/omics/w01-engin-strain-to-scale/examples/project.yaml
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------
+#  Engin project file
+#
+#  Every section is optional. Run whichever stage you have filled in:
+#
+#      engin-host     --config project.yaml     # which chassis?
+#      engin-pathway  --config project.yaml     # which route?
+#      engin-process  --config project.yaml     # what to run next?
+#
+#  Numbers here are illustrative. Nothing in this file has been validated
+#  against your molecule -- see docs.engin.bio/en/latest/limitations.html
+# ---------------------------------------------------------------------------
+
+target: "recombinant lipase (secreted enzyme)"
+
+
+# --------------------------------------------------------------- stage [4]
+# Which host organism to build in.
+host:
+  # How much each capability matters. Any positive numbers -- they are
+  # renormalised, so 2/1 and 20/10 mean the same thing.
+  #
+  #   secretion  exports product rather than holding it inside the cell
+  #   glyco      attaches sugar groups (needed for most therapeutic proteins)
+  #   titer      how much product per litre it tends to reach
+  #   speed      how fast it grows, and how fast you can iterate
+  #   tools      how mature the genetic toolkit is
+  #   scaleup    how well it behaves in a large vessel
+  #   cost       how cheap it is to feed and run
+  #   gras       generally-recognised-as-safe status (food//cosmetic routes)
+  #   smallmol   suited to small-molecule products
+  #   protein    suited to protein products
+  weights:
+    secretion: 1.0
+    titer: 1.0
+    scaleup: 0.7
+    cost: 0.7
+
+  # Minimums. A host scoring below one of these is ranked below every host
+  # that clears them, however good its overall score -- use this for things
+  # that are not tradeable, like glycosylation for a therapeutic protein.
+  hard:
+    secretion: 0.40
+
+
+# --------------------------------------------------------------- stage [3]
+# Which biosynthetic route to build. Each step is scored 0-1, higher = better.
+#
+#   g_thermo    is the reaction thermodynamically downhill?
+#   g_enzyme    is there a characterised, fast enough enzyme?
+#   g_cofactor  does it balance with what the cell can supply?
+#   g_tox       is the intermediate non-toxic to the host?
+#   g_expr      does the enzyme express and fold in this host?
+#
+# NOTE: today these are your judgement, entered by hand -- nothing computes
+# them from structure yet. See github.com/enginbio/engin-suite/issues/140.
+pathway:
+  routes:
+    - id: "route-A"
+      steps:
+        - {g_thermo: 0.80, g_enzyme: 0.70, g_cofactor: 0.90, g_tox: 0.95, g_expr: 0.60}
+        - {g_thermo: 0.60, g_enzyme: 0.85, g_cofactor: 0.75, g_tox: 0.90, g_expr: 0.70}
+    - id: "route-B"
+      steps:
+        - {g_thermo: 0.95, g_enzyme: 0.60, g_cofactor: 0.80, g_tox: 0.40, g_expr: 0.65}
+        - {g_thermo: 0.70, g_enzyme: 0.75, g_cofactor: 0.85, g_tox: 0.90, g_expr: 0.80}
+        - {g_thermo: 0.85, g_enzyme: 0.80, g_cofactor: 0.70, g_tox: 0.95, g_expr: 0.75}
+
+
+# --------------------------------------------------------------- stage [1]
+# Your vessel and your economics. Both default to a 1 L -> 2.5 L, 48 h
+# bench fed-batch, which is almost certainly not yours -- change them.
+process:
+  reactor:
+    v0: 1.0          # starting volume, litres
+    vmax: 2.5        # full working volume; feeding stops here. v0 == vmax is a
+                     # plain batch (no feed) reactor, which is allowed.
+    t_end: 48.0      # run length, hours
+    x0: 0.2          # inoculum biomass, g/L
+
+  cost:
+    substrate_usd_per_kg: 0.55        # what you pay for feedstock
+    reactor_usd_per_L_h: 0.045        # vessel occupancy: capital, utilities, labour
+    downstream_base_usd_per_kg: 46.0  # recovery cost at the reference titer below
+    downstream_reference_titer_g_L: 40.0
+    target_usd_per_kg: 200.0          # the price you need to beat
+
+  batch_size: 4      # how many designs to recommend
+  seed: 0            # same seed, same answer

--- a/workflows/omics/w01-engin-strain-to-scale/pyproject.toml
+++ b/workflows/omics/w01-engin-strain-to-scale/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "w01-engin-strain-to-scale"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+  "horus-environments>=0.1.2",
+  "horus-runtime>=0.3.0",
+]

--- a/workflows/omics/w01-engin-strain-to-scale/scripts/summary.py
+++ b/workflows/omics/w01-engin-strain-to-scale/scripts/summary.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Merge Engin's three stage JSONs into one decision brief.
+
+engin-host, engin-pathway and engin-process each read the same project.yaml
+and answer their own question independently -- this stage is the only place
+that reads across all three. The pure helpers below (summarize_* and
+intervals_overlap) do the merging; everything else is argv/file I/O so the
+helpers can be tested directly (see test_summary.py).
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+CAVEATS = """## How to read this
+
+Engin is honest about being early -- these caveats are the point of the tool,
+not fine print:
+
+- **The calibration transfers; the point prediction does not.** Measured
+  against 406 real industrial fermentation batches, interval coverage lands
+  near its 90% nominal, while predictive R² collapses to roughly 0.02-0.11.
+  Trust the error bars, not the centre of the bar.
+- **engin-host's knowledge base is illustrative.** Capability values are
+  hand-assigned with no citations behind them; the ranking demonstrates the
+  scoring machinery, not evidence about these organisms.
+- **engin-pathway is trained on a synthetic route generator**, and the step
+  features are your own judgement entered by hand. Read the order as a
+  prompt for discussion, not a measurement.
+- **engin-process optimises net $/kg, not titer**, and its runs are
+  simulated from the vessel model in your project file, not read from real
+  run history.
+"""
+
+
+def intervals_overlap(a: tuple[float, float], b: tuple[float, float]) -> bool:
+    """Whether closed intervals *a* and *b* share any point."""
+    a_lo, a_hi = a
+    b_lo, b_hi = b
+    return a_lo <= b_hi and b_lo <= a_hi
+
+
+def summarize_host(doc: dict[str, Any]) -> dict[str, Any]:
+    """Pull the recommendation and top rows out of an engin-host JSON doc."""
+    decision = doc["decision"]
+    return {
+        "host": decision["host"],
+        "score": decision["score"],
+        "band90": decision["band90"],
+        "confidence": decision["confidence"],
+        "key_drivers": decision["key_drivers"],
+        "alternatives": decision["alternatives"],
+        "provenance": doc["ranking"][0]["provenance"],
+        "flags": doc["ranking"][0]["flags"],
+    }
+
+
+def summarize_pathway(doc: dict[str, Any]) -> dict[str, Any]:
+    """Pull the ranking and shortlist-vs-winner call out of an engin-pathway doc."""
+    ranking = doc["ranking"]
+    top_two = ranking[:2]
+    separated = (
+        not intervals_overlap(
+            (top_two[0]["lo"], top_two[0]["hi"]), (top_two[1]["lo"], top_two[1]["hi"])
+        )
+        if len(top_two) == 2
+        else True
+    )
+    return {
+        "routes": [
+            {
+                "route_id": r["route_id"],
+                "manufacturability": r["manufacturability"],
+                "interval": [r["lo"], r["hi"]],
+            }
+            for r in ranking
+        ],
+        "separated": separated,
+        "trained_on": doc["trained_on"],
+        "n_labelled_supplied": doc["n_labelled_supplied"],
+    }
+
+
+def summarize_process(doc: dict[str, Any]) -> dict[str, Any]:
+    """Pull the best-known cost and recommended runs out of an engin-process doc."""
+    best = doc["best_known"]
+    return {
+        "expected_usd_per_kg": best["expected_usd_per_kg"],
+        "interval": [best["lower_usd_per_kg"], best["upper_usd_per_kg"]],
+        "prob_meets_target": best["prob_meets_target"],
+        "target_usd_per_kg": best["target_usd_per_kg"],
+        "recommended": doc["recommended"],
+    }
+
+
+def render_markdown(target: str, host: dict, pathway: dict, process: dict) -> str:
+    lines = [f"# Decision brief -- {target}", ""]
+
+    lines += [
+        "## Host (engin-host)",
+        f"**{host['host']}**, score {host['score']:.2f} ± {host['band90']:.2f} "
+        f"(confidence {host['confidence']:.2f}). "
+        f"Driven by {', '.join(host['key_drivers'])}.",
+        f"Alternatives: {', '.join(host['alternatives'])}.",
+        f"_Basis: {host['provenance']}._",
+        "",
+    ]
+
+    route_lines = [
+        f"- {r['route_id']}: {r['manufacturability']:.3f} "
+        f"[{r['interval'][0]:.3f}, {r['interval'][1]:.3f}]"
+        for r in pathway["routes"]
+    ]
+    verdict = (
+        "Top routes are separated: read the order as a ranking."
+        if pathway["separated"]
+        else "Top routes' intervals overlap: a shortlist, not a winner."
+    )
+    lines += ["## Pathway (engin-pathway)", *route_lines, "", verdict, ""]
+
+    reco_lines = [
+        f"{i}. E[saving]=${r['expected_cost_reduction_usd_per_kg']:.2f}/kg  "
+        f"feed_rate={r['feed_rate']:.4f}  feed_start={r['feed_start']:.2f}  "
+        f"Sf={r['Sf']:.0f}  induction_time={r['induction_time']:.2f}  S0={r['S0']:.1f}"
+        for i, r in enumerate(process["recommended"], start=1)
+    ]
+    lines += [
+        "## Process (engin-process)",
+        f"Best known cost: ${process['expected_usd_per_kg']:.2f}/kg "
+        f"[${process['interval'][0]:.2f}, ${process['interval'][1]:.2f}] (90%). "
+        f"Clears ${process['target_usd_per_kg']:.0f}/kg target with "
+        f"probability {process['prob_meets_target']:.2f}.",
+        "",
+        "Next runs, by expected cost reduction:",
+        *reco_lines,
+        "",
+        CAVEATS,
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", required=True, type=Path)
+    parser.add_argument("--pathway", required=True, type=Path)
+    parser.add_argument("--process", required=True, type=Path)
+    parser.add_argument("--out-json", required=True, type=Path)
+    parser.add_argument("--out-md", required=True, type=Path)
+    args = parser.parse_args()
+
+    host_doc = json.loads(args.host.read_text())
+    pathway_doc = json.loads(args.pathway.read_text())
+    process_doc = json.loads(args.process.read_text())
+
+    host = summarize_host(host_doc)
+    pathway = summarize_pathway(pathway_doc)
+    process = summarize_process(process_doc)
+    target = host_doc.get("target", pathway_doc.get("target", process_doc.get("target")))
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(
+        json.dumps(
+            {"target": target, "host": host, "pathway": pathway, "process": process},
+            indent=2,
+        )
+        + "\n"
+    )
+    args.out_md.write_text(render_markdown(target, host, pathway, process) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/omics/w01-engin-strain-to-scale/scripts/test_summary.py
+++ b/workflows/omics/w01-engin-strain-to-scale/scripts/test_summary.py
@@ -1,0 +1,53 @@
+"""Tests for the pure merge helpers in summary.py, against the captured
+example outputs in examples/expected-output/ (deterministic under seed: 0).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))  # summary.py sits next to this file
+
+import pytest
+from summary import intervals_overlap, summarize_host, summarize_pathway, summarize_process
+
+EXPECTED = Path(__file__).parent.parent / "examples" / "expected-output"
+
+
+def _load(name: str) -> dict:
+    return json.loads((EXPECTED / name).read_text())
+
+
+def test_summarize_host() -> None:
+    summary = summarize_host(_load("engin-host.json"))
+    assert summary["host"] == "P. pastoris"
+    assert summary["score"] == pytest.approx(0.8294, abs=1e-3)
+    assert summary["confidence"] == pytest.approx(0.6811, abs=1e-3)
+    assert summary["provenance"] == "illustrative"
+    assert "secretion" in summary["key_drivers"]
+
+
+def test_summarize_pathway_top_routes_overlap() -> None:
+    summary = summarize_pathway(_load("engin-pathway.json"))
+    assert summary["separated"] is False  # route-A and route-B intervals overlap
+    assert summary["trained_on"] == "synthetic generator"
+    assert summary["routes"][0]["route_id"] == "route-A"
+
+
+def test_summarize_process() -> None:
+    summary = summarize_process(_load("engin-process.json"))
+    assert summary["prob_meets_target"] == 1.0
+    assert summary["expected_usd_per_kg"] == pytest.approx(49.89, abs=0.01)
+    assert len(summary["recommended"]) == 4
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ((0.532, 0.754), (0.524, 0.747), True),  # route-A vs route-B: overlap
+        ((0.0, 0.1), (0.2, 0.3), False),  # disjoint
+        ((0.0, 0.5), (0.5, 1.0), True),  # touching endpoints count as overlap
+    ],
+)
+def test_intervals_overlap(a: tuple, b: tuple, expected: bool) -> None:
+    assert intervals_overlap(a, b) is expected

--- a/workflows/omics/w01-engin-strain-to-scale/workflow.yaml
+++ b/workflows/omics/w01-engin-strain-to-scale/workflow.yaml
@@ -1,0 +1,203 @@
+kind: horus_workflow
+name: Engin Strain-to-Scale
+
+artifacts:
+  - id: project
+    name: Engin project file
+    description: Single project.yaml read by all three Engin stages -- host
+      weights, candidate routes, and vessel/cost economics.
+    kind: file
+    path: examples/project.yaml
+
+tasks:
+  # `summary` is listed first, even though it depends on the other three,
+  # because `horus run` with no --trigger defaults to `tasks[0]`, and its
+  # scope is ancestors(trigger) | descendants(trigger). host/pathway/process
+  # share no task-to-task edge (each is an independent read of `project`),
+  # so no single one of them has the other two in its ancestors or
+  # descendants -- only `summary`, their common descendant, does. Triggering
+  # anywhere else runs just that one branch plus `summary` (which then
+  # blocks forever on the missing inputs). List order otherwise doesn't
+  # matter; edges below define the real dependency graph.
+  - kind: horus_task
+    id: summary
+    name: Build the decision brief
+    description: Merges the three stage JSONs into one summary.json and a
+      summary.md brief that keeps each stage's interval and its
+      illustrative/synthetic/judgement caveats visible.
+    inputs:
+      - id: host_json
+        name: Host ranking (JSON)
+        kind: file
+        path: results/host.json
+      - id: pathway_json
+        name: Pathway ranking (JSON)
+        kind: file
+        path: results/pathway.json
+      - id: process_json
+        name: Process plan (JSON)
+        kind: file
+        path: results/process.json
+    outputs:
+      - id: summary_json
+        name: Decision brief (JSON)
+        kind: file
+        path: results/summary.json
+      - id: summary_md
+        name: Decision brief (Markdown)
+        kind: file
+        path: results/summary.md
+    executor:
+      kind: shell
+    runtime:
+      kind: python_script
+      script: scripts/summary.py
+      python: python3 # stdlib-only; use the target's python3
+      args: >-
+        --host ${host_json} --pathway ${pathway_json} --process ${process_json}
+        --out-json ${summary_json} --out-md ${summary_md}
+    target:
+      kind: local
+
+  # host, pathway and process all read the same project.yaml and answer their
+  # own independent question -- none consumes another's output. So this is
+  # one input artifact fanning out to three parallel tasks, not a pipeline.
+  # Each stage writes both --json (for `summary` and for scripting) and the
+  # plain report (for a human to read the caveats in).
+  - kind: horus_task
+    id: host
+    name: engin-host -- which chassis?
+    description: Ranks candidate host organisms against project.yaml's capability
+      weights and hard constraints.
+    inputs:
+      - id: project
+        name: Engin project file
+        kind: file
+        path: examples/project.yaml
+    outputs:
+      - id: host_json
+        name: Host ranking (JSON)
+        kind: file
+        path: results/host.json
+      - id: host_txt
+        name: Host ranking (report)
+        kind: file
+        path: results/host.txt
+    resources:
+      cpus: 1
+      memory_gb: 2
+    executor:
+      kind: uv_python_environment
+      python: "3.11"
+      requirements:
+        - engin-host[cli]==0.1.1
+    runtime:
+      kind: command
+      command: >-
+        engin-host --config ${project} --json > ${host_json}
+        && engin-host --config ${project} > ${host_txt}
+    target:
+      kind: local
+
+  - kind: horus_task
+    id: pathway
+    name: engin-pathway -- which route?
+    description: Ranks candidate biosynthetic routes from project.yaml by
+      predicted manufacturability, with a 90% interval.
+    inputs:
+      - id: project
+        name: Engin project file
+        kind: file
+        path: examples/project.yaml
+    outputs:
+      - id: pathway_json
+        name: Pathway ranking (JSON)
+        kind: file
+        path: results/pathway.json
+      - id: pathway_txt
+        name: Pathway ranking (report)
+        kind: file
+        path: results/pathway.txt
+    resources:
+      cpus: 1
+      memory_gb: 2
+    executor:
+      kind: uv_python_environment
+      python: "3.11"
+      requirements:
+        - engin-pathway[cli]==0.1.1
+    runtime:
+      kind: command
+      command: >-
+        engin-pathway --config ${project} --json > ${pathway_json}
+        && engin-pathway --config ${project} > ${pathway_txt}
+    target:
+      kind: local
+
+  - kind: horus_task
+    id: process
+    name: engin-process -- what to run next?
+    description: Costs the current process against project.yaml's vessel and
+      economics, and proposes the next runs by expected cost reduction.
+    inputs:
+      - id: project
+        name: Engin project file
+        kind: file
+        path: examples/project.yaml
+    outputs:
+      - id: process_json
+        name: Process plan (JSON)
+        kind: file
+        path: results/process.json
+      - id: process_txt
+        name: Process plan (report)
+        kind: file
+        path: results/process.txt
+    resources:
+      cpus: 1
+      memory_gb: 2
+    executor:
+      kind: uv_python_environment
+      python: "3.11"
+      # engin-process ships as part of engin-core; engin-host[cli] pulls in
+      # engin-core[cli] (see w01-engin-strain-to-scale/README.md).
+      requirements:
+        - engin-host[cli]==0.1.1
+    runtime:
+      kind: command
+      command: >-
+        engin-process --config ${project} --json > ${process_json}
+        && engin-process --config ${project} > ${process_txt}
+    target:
+      kind: local
+
+edges:
+  - source: artifact-project
+    source_output: project
+    target: host
+    target_input: project
+  - source: artifact-project
+    source_output: project
+    target: pathway
+    target_input: project
+  - source: artifact-project
+    source_output: project
+    target: process
+    target_input: project
+
+  - source: host
+    source_output: host_json
+    target: summary
+    target_input: host_json
+  - source: pathway
+    source_output: pathway_json
+    target: summary
+    target_input: pathway_json
+  - source: process
+    source_output: process_json
+    target: summary
+    target_input: process_json
+
+orchestrator_target:
+  kind: local
+  working_directory: horus_workflow_results


### PR DESCRIPTION
Adds workflows/omics/w01-engin-strain-to-scale/, wrapping Engin's three independent bioprocess decision-aid CLIs (engin-host, engin-pathway, engin-process) as a fan-out/fan-in Horus workflow: one project.yaml artifact feeds three parallel tasks, merged by a stdlib summary task into one summary.{json,md} decision brief that preserves each stage's interval and illustrative/synthetic/judgement caveats.

Notes for reviewers:
- summary is listed first in workflow.yaml's tasks: (commented) — horus run's default --trigger is tasks[0], and since the three Engin tasks share no task-to-task edge with each other, only their common descendant (summary) has scope covering the whole graph. Verified uv run horus run workflow.yaml with no flags runs all four tasks.
- examples/expected-output/ was captured from a dev checkout of engin-suite, not the published 0.1.1 wheel — the live package's host.json lacks the EFSA QPS section the example shows. scripts/summary.py only reads fields present in both shapes, so unaffected; documented in the workflow README.
- scripts/test_summary.py covers the merge/interval-overlap logic against the bundled example JSON (uv run --with pytest pytest scripts/test_summary.py).

Also adds an Omics section + W-33 row to the root README.